### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+---
+
+## [0.7.2] - 2026-04-01
+
 ### Added
 
 - **`source:` prefix in search help** — `source:` is now listed under "Scope prefixes" in the `?` help panel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "find-client"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "find-common"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "find-content-store"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "find-common",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-archive"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dicom"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "dicom-dictionary-std",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dispatch"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "find-extract-dicom",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-epub"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-html"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-media"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-office"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "calamine",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pdf"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pe"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-text"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "content_inspector",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "find-handler"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "url",
 ]
@@ -1701,7 +1701,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "find-preview-dicom"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "dicom-object",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "find-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-client"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [[bin]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-common"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/content-store/Cargo.toml
+++ b/crates/content-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-content-store"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/archive/Cargo.toml
+++ b/crates/extractors/archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-archive"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dicom/Cargo.toml
+++ b/crates/extractors/dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dicom"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dispatch/Cargo.toml
+++ b/crates/extractors/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dispatch"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/epub/Cargo.toml
+++ b/crates/extractors/epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-epub"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/html/Cargo.toml
+++ b/crates/extractors/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-html"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/media/Cargo.toml
+++ b/crates/extractors/media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-media"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/office/Cargo.toml
+++ b/crates/extractors/office/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-office"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pdf/Cargo.toml
+++ b/crates/extractors/pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pdf"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pe/Cargo.toml
+++ b/crates/extractors/pe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pe"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/text/Cargo.toml
+++ b/crates/extractors/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-text"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [lib]

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-handler"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [[bin]]

--- a/crates/preview-dicom/Cargo.toml
+++ b/crates/preview-dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-preview-dicom"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [[bin]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-server"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Version bump to 0.7.2 — native iWork extraction, IWA structured protobuf parsing, iWork preview viewer, image rotate buttons.