### PR TITLE
fix: dim stale results while typing in Ctrl+P palette

### DIFF
--- a/web/src/lib/CommandPalette.svelte
+++ b/web/src/lib/CommandPalette.svelte
@@ -23,6 +23,7 @@
 	let inputEl: HTMLInputElement;
 	let results: SourcedFile[] = [];
 	let loading = false;
+	let stale = false;
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 	$: isAll = totalSourceCount > 1 && sources.length >= totalSourceCount;
@@ -51,6 +52,7 @@
 
 	function scheduleSearch(q: string) {
 		if (debounceTimer) clearTimeout(debounceTimer);
+		stale = true;
 		debounceTimer = setTimeout(() => fetchResults(q), 500);
 	}
 
@@ -70,6 +72,7 @@
 			// partial failures silently yield no items for that source
 		} finally {
 			loading = false;
+			stale = false;
 		}
 	}
 
@@ -136,7 +139,7 @@
 					on:keydown={onKeydown}
 				/>
 			</div>
-			<div class="cp-results">
+			<div class="cp-results" class:stale>
 				{#if results.length === 0 && loading}
 					<div class="cp-status">Loading…</div>
 				{:else if results.length === 0}
@@ -238,6 +241,10 @@
 		max-height: 360px;
 		overflow-y: auto;
 		overflow-x: hidden;
+	}
+
+	.cp-results.stale {
+		opacity: 0.4;
 	}
 
 	.cp-status {


### PR DESCRIPTION
## Summary

- Adds a `stale` boolean state variable to `CommandPalette.svelte`
- Sets `stale = true` immediately when the user begins typing (in `scheduleSearch`), before the 500ms debounce fires
- Resets `stale = false` in the `finally` block of `fetchResults` once new results arrive
- Applies `opacity: 0.4` to `.cp-results` when `stale` is true, giving clear visual feedback that the displayed results are outdated

## Test plan

- [x] All 187 existing Vitest unit tests pass (`pnpm run test`)
- [x] TypeScript/Svelte type check passes with 0 errors (`pnpm run check`)
- Manual verification: open palette with Ctrl+P, start typing — existing results dim immediately, then return to full opacity when new results load

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/claude-code)