### PR TITLE
fix: register inotify watch on new directory after rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Directory renames not watched after rename** — when `find-watch` detected a directory rename pair, the new directory path was removed from the batch (correct) but `register_dir` was never called for it, so the new location had no inotify watch. Changes inside the renamed directory were silently missed until the next full rescan.
+
 ---
 
 ## [0.7.2] - 2026-04-01

--- a/crates/client/src/watch.rs
+++ b/crates/client/src/watch.rs
@@ -209,7 +209,12 @@ where
         let fresh_creates = std::mem::take(&mut first_seen_creates);
 
         // Detect rename pairs and process them; removes paired entries from batch.
-        process_renames(&mut batch, source_map, scan, extractor_dir, api, &fresh_creates).await;
+        // Returns new directory paths from dir-rename pairs that need inotify watches.
+        let dirs_needing_watch =
+            process_renames(&mut batch, source_map, scan, extractor_dir, api, &fresh_creates).await;
+        for dir in &dirs_needing_watch {
+            register_dir(dir);
+        }
 
         for (abs_path, kind) in batch {
             // Skip paths that contain '::' — those are archive member paths
@@ -702,6 +707,12 @@ async fn handle_delete(
 /// Detect rename pairs in a debounce-flush batch and send the appropriate
 /// `BulkRequest`s. Removes handled entries from `batch` so the caller's
 /// fallback loop can process remaining events with standard delete/update logic.
+///
+/// Returns the new directory paths that were part of directory rename pairs.
+/// The caller must call `register_dir` on each returned path so that an
+/// inotify watch is registered for the new location — the rename detection
+/// removes `new_dir` from the batch, which would otherwise prevent the main
+/// event loop from calling `register_dir` for it.
 async fn process_renames(
     batch: &mut HashMap<PathBuf, AccumulatedKind>,
     source_map: &SourceMap,
@@ -709,7 +720,7 @@ async fn process_renames(
     extractor_dir: &Option<String>,
     api: &ApiClient,
     first_seen_creates: &HashSet<PathBuf>,
-) {
+) -> Vec<PathBuf> {
     // --- Directory rename detection ---
     // Look for a Delete path paired with an Update path that is a directory,
     // in the same parent directory and the same source (1:1 per parent).
@@ -743,6 +754,8 @@ async fn process_renames(
     }
 
     let mut handled: HashSet<PathBuf> = HashSet::new();
+    // New directory locations from rename pairs that need inotify watches registered.
+    let mut dirs_needing_watch: Vec<PathBuf> = Vec::new();
 
     for (parent, del_paths) in &del_by_parent {
         let Some(upd_dirs) = dir_upd_by_parent.get(parent) else { continue };
@@ -781,6 +794,11 @@ async fn process_renames(
         {
             warn!("dir rename {} → {}: {e:#}", old_dir.display(), new_dir.display());
         }
+
+        // The kernel automatically removes the inotify watch on old_dir when it
+        // is renamed/deleted. new_dir has no watch yet — record it so the caller
+        // can call register_dir on it.
+        dirs_needing_watch.push(new_dir.clone());
 
         // Mark the directory entries and all child events as handled.
         handled.insert(old_dir.clone());
@@ -898,6 +916,8 @@ async fn process_renames(
     for p in &file_handled {
         batch.remove(p);
     }
+
+    dirs_needing_watch
 }
 
 /// Walk `new_dir` on disk, re-evaluate include/exclude rules for each file,

--- a/crates/server/src/normalize.rs
+++ b/crates/server/src/normalize.rs
@@ -963,20 +963,31 @@ mod tests {
     }
 
     /// Build a NormalizationSettings with a single batch-mode formatter.
-    /// Uses short timeouts (2s) so tests exercise the fallback path quickly.
+    /// Uses generous timeouts (30s) so correctness tests don't flake on loaded CI.
     #[cfg(unix)]
     fn batch_cfg(script_path: &str, ext: &str, args: Vec<&str>) -> NormalizationSettings {
         use find_common::config::FormatterConfig;
         NormalizationSettings {
             max_line_length: 10_000,
-            batch_formatter_timeout_secs: 2,
-            per_file_formatter_timeout_secs: 2,
+            batch_formatter_timeout_secs: 30,
+            per_file_formatter_timeout_secs: 30,
             formatters: vec![FormatterConfig {
                 path: script_path.to_string(),
                 args: args.into_iter().map(str::to_string).collect(),
                 extensions: vec![ext.to_string()],
                 mode: find_common::config::FormatterMode::Batch,
             }],
+        }
+    }
+
+    /// Like `batch_cfg` but with a 2-second timeout so `batch_timeout_falls_back_to_per_file`
+    /// exercises the timeout path quickly without waiting 30 seconds.
+    #[cfg(unix)]
+    fn batch_cfg_tight_timeout(script_path: &str, ext: &str, args: Vec<&str>) -> NormalizationSettings {
+        NormalizationSettings {
+            batch_formatter_timeout_secs: 2,
+            per_file_formatter_timeout_secs: 2,
+            ..batch_cfg(script_path, ext, args)
         }
     }
 
@@ -1116,10 +1127,10 @@ fi
     #[test]
     fn batch_timeout_falls_back_to_per_file() {
         // The script hangs when given multiple files → triggers the batch timeout
-        // (2s in test builds).  The per-file fallback then re-runs the formatter
-        // on each file individually, where it finds exactly one file and succeeds.
+        // (2s).  The per-file fallback then re-runs the formatter on each file
+        // individually, where it finds exactly one file and succeeds.
         let (_dir, script) = make_script("hang_multi.sh", HANG_MULTI_BATCH);
-        let cfg = batch_cfg(script.to_str().unwrap(), "js", vec!["{dir}"]);
+        let cfg = batch_cfg_tight_timeout(script.to_str().unwrap(), "js", vec!["{dir}"]);
 
         let mut files = vec![
             make_batch_entry(0, "a.js", &["console.log('a')"]),

--- a/crates/server/tests/admin.rs
+++ b/crates/server/tests/admin.rs
@@ -267,6 +267,9 @@ async fn test_inbox_clear_all() {
 async fn test_inbox_retry_moves_failed_to_pending() {
     let srv = TestServer::spawn().await;
 
+    // Pause the worker so it doesn't pick up and re-fail the fake file.
+    srv.client.post(srv.url("/api/v1/admin/inbox/pause")).send().await.unwrap();
+
     // Write a .gz directly into the failed dir.
     let failed_dir = srv.data_dir_path().join("inbox/failed");
     std::fs::create_dir_all(&failed_dir).unwrap();
@@ -282,10 +285,12 @@ async fn test_inbox_retry_moves_failed_to_pending() {
         .send().await.unwrap().json().await.unwrap();
     assert_eq!(retry.retried, 1, "should retry exactly one file");
 
+    // With worker paused, the file stays in pending (not re-failed).
     let after: InboxStatusResponse = srv.client
         .get(srv.url("/api/v1/admin/inbox"))
         .send().await.unwrap().json().await.unwrap();
     assert!(after.failed.is_empty(), "failed should be empty after retry");
+    assert!(!after.pending.is_empty(), "item should be in pending after retry");
 }
 
 // ── inbox pause stops processing ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

When \`find-watch\` detected a directory rename pair (old_dir → new_dir), it correctly removed \`new_dir\` from the batch to avoid double-processing, but never called \`register_dir\` for it. The kernel automatically removes the inotify watch when a directory is renamed/deleted, so \`new_dir\` ended up with no watch. File changes inside the renamed directory were silently missed until the next full rescan.

\`process_renames\` now returns \`Vec<PathBuf>\` of the new directory paths from rename pairs. The flush loop calls \`register_dir\` on each.

## Test plan

- [ ] Rename a watched directory and verify that file changes inside the renamed directory are still detected
- [ ] \`mise run clippy\` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)