### PR TITLE
feat: cross_filesystems option + doc mode all-lines search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **Document mode shows all matching lines** — `doc:` search now returns one result per matching line (any keyword) for each qualifying file, rather than a single representative. Lines are capped at 20 per file; a `+` badge on the hit counter indicates truncation. Hits are sorted by line number and navigable via chevrons.
+
 - **`cross_filesystems` config option** — `[scan] cross_filesystems = false` (default) prevents the walker from descending into directories on a different device than the walk root, avoiding accidental traversal of mounted backup volumes, borg archives, network shares, and bind mounts. Set to `true` to restore the previous behaviour of crossing filesystem boundaries.
 
 - **Windows service starts immediately after install** — `install_service` now calls `service.start()` after creating the service so no reboot or manual `sc start` is needed; output message updated accordingly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **`cross_filesystems` config option** — `[scan] cross_filesystems = false` (default) prevents the walker from descending into directories on a different device than the walk root, avoiding accidental traversal of mounted backup volumes, borg archives, network shares, and bind mounts. Set to `true` to restore the previous behaviour of crossing filesystem boundaries.
+
 - **Windows service starts immediately after install** — `install_service` now calls `service.start()` after creating the service so no reboot or manual `sc start` is needed; output message updated accordingly
 - **Windows installer task checkboxes** — "Start file watcher service" and "Run full scan now" are now proper Inno Setup `[Tasks]` checkboxes rather than a fixed `[Run]` entry, so they run in the same elevated context as the rest of the install
 - **Configurable formatter timeouts** — `batch_formatter_timeout_secs` (default 60) and `per_file_formatter_timeout_secs` (default 10) added to `[normalization]` in `server.toml`; previously hardcoded constants with `#[cfg(test)]` overrides

--- a/crates/client/src/walk.rs
+++ b/crates/client/src/walk.rs
@@ -74,6 +74,20 @@ pub(crate) fn walk_source_tree(
     // before we descend into it.
     let mut override_stack: Vec<(usize, HashSet<String>)> = Vec::new();
 
+    // Device ID of the walk root, captured once for filesystem-boundary checks.
+    // None when cross_filesystems = true (check disabled) or on non-Unix.
+    let root_dev: Option<u64> = if !scan.cross_filesystems {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            std::fs::metadata(walk_root).ok().map(|m| m.dev())
+        }
+        #[cfg(not(unix))]
+        { None }
+    } else {
+        None
+    };
+
     for entry in WalkDir::new(walk_root)
         .follow_links(scan.follow_symlinks)
         .into_iter()
@@ -103,6 +117,22 @@ pub(crate) fn walk_source_tree(
                 if e.path().join(&scan.noindex_file).exists() {
                     tracing::debug!("walk: skipping {} (.noindex present)", e.path().display());
                     return false;
+                }
+
+                // Filesystem boundary check: skip directories on a different
+                // device than the walk root (mount points, bind mounts, etc.).
+                #[cfg(unix)]
+                if let Some(dev) = root_dev {
+                    use std::os::unix::fs::MetadataExt;
+                    if let Ok(meta) = e.metadata() {
+                        if meta.dev() != dev {
+                            tracing::debug!(
+                                "walk: skipping filesystem boundary: {}",
+                                e.path().display()
+                            );
+                            return false;
+                        }
+                    }
                 }
 
                 if let Ok(rel) = e.path().strip_prefix(strip_root) {
@@ -177,6 +207,7 @@ pub(crate) fn walk_source_tree(
             Ok(e) => {
                 let abs = e.path().to_path_buf();
                 if e.file_type().is_dir() {
+                    tracing::debug!("walk: entering dir {}", abs.display());
                     callback(WalkItem::Dir(abs));
                 } else if e.file_type().is_file()
                     && e.file_name().to_str().unwrap_or("") != scan.index_file

--- a/crates/common/src/api.rs
+++ b/crates/common/src/api.rs
@@ -268,6 +268,9 @@ pub struct SearchResult {
     /// Each entry is the best matching line for a term not covered by `line_number`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_matches: Vec<ContextLine>,
+    /// True when this file had more matching lines than the display cap (document mode only).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub hits_truncated: bool,
 }
 
 /// GET /api/v1/search response.

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -170,6 +170,13 @@ pub struct ScanConfig {
     #[serde(default)]
     pub follow_symlinks: bool,
 
+    /// When false (default), do not descend into directories that reside on a
+    /// different filesystem than the walk root.  This prevents accidentally
+    /// traversing mounted backup volumes, network shares, bind mounts, etc.
+    /// Set to `true` to allow crossing filesystem boundaries.
+    #[serde(default)]
+    pub cross_filesystems: bool,
+
     #[serde(default)]
     pub include_hidden: bool,
 
@@ -251,6 +258,7 @@ impl Default for ScanConfig {
             exclude_extra: vec![],
             max_content_size_mb: default_max_content_size_mb(),
             follow_symlinks: false,
+            cross_filesystems: false,
             include_hidden: false,
             archives: ArchiveConfig::default(),
             noindex_file: default_noindex_file(),

--- a/crates/common/src/defaults_client.toml
+++ b/crates/common/src/defaults_client.toml
@@ -14,6 +14,7 @@
 [scan]
 max_content_size_mb     = 10
 follow_symlinks         = false
+cross_filesystems       = false
 include_hidden          = false
 noindex_file            = ".noindex"
 index_file              = ".index"

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -23,7 +23,8 @@ pub use constants::{
     MAX_LINES_PER_FILE, SQL_FTS_FILE_ID, SQL_FTS_FILENAME_ONLY, SQL_FTS_LINE_NUMBER,
 };
 pub use search::{
-    document_candidates, fetch_duplicates_for_file_ids, fts_candidates, DateFilter,
+    build_doc_or_expr, document_all_lines, document_candidates, document_qualifying_ids,
+    fetch_duplicates_for_file_ids, fts_candidates, DateFilter,
 };
 pub use stats::{
     do_cleanup_writes, get_files_pending_content, get_fts_row_count, get_indexing_error,

--- a/crates/server/src/db/search.rs
+++ b/crates/server/src/db/search.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use rusqlite::{Connection, params};
@@ -317,8 +317,6 @@ pub fn document_candidates(
     limit: usize,
     date: DateFilter,
 ) -> Result<DocumentCandidates> {
-    use std::collections::HashSet;
-
     let tokens: Vec<String> = query
         .split_whitespace()
         .filter(|w| w.len() >= 3)
@@ -391,25 +389,154 @@ pub fn document_candidates(
         return Ok((0, vec![]));
     }
 
+    // Representative per file: the globally best-ranked line (used by DocRegex for pre-filtering).
     let or_expr = tokens
         .iter()
         .map(|t| format!("\"{}\"", t.replace('"', "\"\"")))
         .collect::<Vec<_>>()
         .join(" OR ");
-
-    let per_file_cap = tokens.len().max(1);
-    let fetch_limit = (limit * 20 * per_file_cap).max(10_000) as i64;
-
-    struct RawRow {
-        file_path: String,
-        file_kind: FileKind,
-        line_number: usize,
-        file_id: i64,
-        mtime: i64,
-        size: Option<i64>,
+    let fetch_limit = (limit * 20).max(10_000) as i64;
+    let mut file_order: Vec<i64> = Vec::new();
+    let mut representative_map: HashMap<i64, CandidateRow> = HashMap::new();
+    {
+        let sql = format!(
+            "SELECT f.path, f.kind, {SQL_FTS_LINE_NUMBER} AS line_number,
+                    f.id, f.mtime, f.size
+             FROM lines_fts
+             JOIN files f ON f.id = {SQL_FTS_FILE_ID}
+             WHERE lines_fts MATCH ?1
+             ORDER BY lines_fts.rank
+             LIMIT ?2",
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let mut rows = stmt.query(params![or_expr, fetch_limit])?;
+        while let Some(row) = rows.next()? {
+            let file_id: i64 = row.get(3)?;
+            if !qualifying_ids.contains(&file_id) || representative_map.contains_key(&file_id) {
+                continue;
+            }
+            file_order.push(file_id);
+            let file_kind_str: String = row.get(1)?;
+            let (file_path, archive_path) = split_composite_path(&row.get::<_, String>(0)?);
+            representative_map.insert(file_id, CandidateRow {
+                file_path,
+                file_kind:   FileKind::from(file_kind_str.as_str()),
+                archive_path,
+                line_number: row.get::<_, i64>(2)? as usize,
+                content:     String::new(),
+                mtime:       row.get(4)?,
+                size:        row.get(5)?,
+                file_id,
+            });
+            if file_order.len() >= limit { break; }
+        }
     }
 
-    let mut stmt = conn.prepare(&format!(
+    let mut results = Vec::new();
+    for file_id in file_order.into_iter().take(limit) {
+        if let Some(representative) = representative_map.remove(&file_id) {
+            results.push(DocumentGroup { representative, members: vec![] });
+        }
+    }
+
+    Ok((total, results))
+}
+
+/// Build the FTS OR expression for a whitespace-separated query string.
+/// Returns `None` when no token is long enough to query.
+pub fn build_doc_or_expr(query: &str) -> Option<String> {
+    let parts: Vec<String> = query
+        .split_whitespace()
+        .filter(|w| w.len() >= 3)
+        .map(|t| format!("\"{}\"", t.replace('"', "\"\"")))
+        .collect();
+    if parts.is_empty() { None } else { Some(parts.join(" OR ")) }
+}
+
+/// Return the set of file IDs that contain ALL whitespace-separated tokens in `query`,
+/// optionally filtered by date/kind/path prefix.
+pub fn document_qualifying_ids(
+    conn: &Connection,
+    query: &str,
+    date: DateFilter,
+) -> Result<HashSet<i64>> {
+    let tokens: Vec<String> = query
+        .split_whitespace()
+        .filter(|w| w.len() >= 3)
+        .map(|w| w.to_string())
+        .collect();
+
+    if tokens.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let mut per_token_ids: Vec<HashSet<i64>> = Vec::new();
+    for token in &tokens {
+        let fts_expr = format!("\"{}\"", token.replace('"', "\"\""));
+        let mut stmt = conn.prepare(&format!(
+            "SELECT DISTINCT {SQL_FTS_FILE_ID} AS file_id
+             FROM lines_fts
+             JOIN files f ON f.id = {SQL_FTS_FILE_ID}
+             WHERE lines_fts MATCH ?1
+             LIMIT 100000",
+        ))?;
+        let ids: HashSet<i64> = stmt
+            .query_map(params![fts_expr], |row| row.get(0))?
+            .collect::<rusqlite::Result<_>>()?;
+        per_token_ids.push(ids);
+    }
+
+    let mut qualifying_ids: HashSet<i64> = per_token_ids
+        .into_iter()
+        .reduce(|a, b| a.intersection(&b).copied().collect())
+        .unwrap_or_default();
+
+    if date.is_active() && !qualifying_ids.is_empty() {
+        let from = date.from.unwrap_or(i64::MIN);
+        let to   = date.to.unwrap_or(i64::MAX);
+        let mut p = ParamBinder::new();
+        let from_ph = p.push(from);
+        let to_ph   = p.push(to);
+        let id_phs  = qualifying_ids.iter().map(|&id| p.push(id)).collect::<Vec<_>>().join(", ");
+        let kind_clause = if date.kinds.is_empty() {
+            String::new()
+        } else {
+            let phs = date.kinds.iter().map(|k| p.push(k.to_string())).collect::<Vec<_>>().join(", ");
+            format!("AND kind IN ({phs})")
+        };
+        let path_prefix_clause = if let Some(ref prefix) = date.path_prefix {
+            let eq_ph   = p.push(prefix.clone());
+            let like_ph = p.push(format!("{prefix}/%"));
+            format!("AND (path = {eq_ph} OR path LIKE {like_ph})")
+        } else {
+            String::new()
+        };
+        let sql = format!(
+            "SELECT id FROM files WHERE id IN ({id_phs}) AND mtime BETWEEN {from_ph} AND {to_ph} {kind_clause} {path_prefix_clause}"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let refs = p.as_refs();
+        qualifying_ids = stmt
+            .query_map(refs.as_slice(), |row| row.get(0))?
+            .collect::<rusqlite::Result<HashSet<i64>>>()?;
+    }
+
+    Ok(qualifying_ids)
+}
+
+/// Fetch all lines from `qualifying_ids` that match `or_expr`, capped at `per_file_limit`
+/// lines per file and `total_limit` rows overall.
+/// Returns `(candidates, truncated_ids)` where `truncated_ids` contains file IDs that
+/// had more matching lines than the cap.
+pub fn document_all_lines(
+    conn: &Connection,
+    qualifying_ids: &HashSet<i64>,
+    or_expr: &str,
+    per_file_limit: usize,
+    total_limit: usize,
+) -> Result<(Vec<CandidateRow>, HashSet<i64>)> {
+    let fetch_limit = (total_limit * per_file_limit * 2).max(50_000) as i64;
+    let sql = format!(
         "SELECT f.path, f.kind, {SQL_FTS_LINE_NUMBER} AS line_number,
                 f.id, f.mtime, f.size
          FROM lines_fts
@@ -417,60 +544,51 @@ pub fn document_candidates(
          WHERE lines_fts MATCH ?1
          ORDER BY lines_fts.rank
          LIMIT ?2",
-    ))?;
-
-    // Collect up to `per_file_cap` raw rows per qualifying file.
-    let mut file_rows: HashMap<i64, Vec<RawRow>> = HashMap::new();
-    let mut file_order: Vec<i64> = Vec::new();
-
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query(params![or_expr, fetch_limit])?;
+
+    let mut file_hits: HashMap<i64, Vec<CandidateRow>> = HashMap::new();
+    let mut file_order: Vec<i64> = Vec::new();
+    let mut truncated_ids: HashSet<i64> = HashSet::new();
+
     while let Some(row) = rows.next()? {
         let file_id: i64 = row.get(3)?;
-        if !qualifying_ids.contains(&file_id) {
-            continue;
-        }
-        let entry = file_rows.entry(file_id).or_insert_with(|| {
+        if !qualifying_ids.contains(&file_id) { continue; }
+        let entry = file_hits.entry(file_id).or_insert_with(|| {
             file_order.push(file_id);
             Vec::new()
         });
-        if entry.len() < per_file_cap {
-            let file_kind_str: String = row.get(1)?;
-            entry.push(RawRow {
-                file_path:   row.get(0)?,
-                file_kind:   FileKind::from(file_kind_str.as_str()),
-                line_number: row.get::<_, i64>(2)? as usize,
-                file_id,
-                mtime:       row.get(4)?,
-                size:        row.get(5)?,
-            });
+        if entry.len() >= per_file_limit {
+            truncated_ids.insert(file_id);
+            continue;
         }
-        if file_order.len() >= limit && file_rows.get(&file_order[file_order.len()-1]).map_or(0, |v| v.len()) >= per_file_cap {
+        let file_kind_str: String = row.get(1)?;
+        let (file_path, archive_path) = split_composite_path(&row.get::<_, String>(0)?);
+        entry.push(CandidateRow {
+            file_path,
+            file_kind:   FileKind::from(file_kind_str.as_str()),
+            archive_path,
+            line_number: row.get::<_, i64>(2)? as usize,
+            content:     String::new(),
+            mtime:       row.get(4)?,
+            size:        row.get(5)?,
+            file_id,
+        });
+        if file_order.len() >= total_limit
+            && file_hits.get(&file_order[file_order.len() - 1]).map_or(0, |v| v.len()) >= per_file_limit
+        {
             break;
         }
     }
 
-    let mut results = Vec::new();
-    for file_id in file_order.into_iter().take(limit) {
-        let rows = match file_rows.remove(&file_id) {
-            Some(r) => r,
-            None => continue,
-        };
-        let rep_row = &rows[0];
-        let (file_path, archive_path) = split_composite_path(&rep_row.file_path);
-        let representative = CandidateRow {
-            file_path,
-            file_kind:   rep_row.file_kind.clone(),
-            archive_path,
-            line_number: rep_row.line_number,
-            content:     String::new(),
-            mtime:       rep_row.mtime,
-            size:        rep_row.size,
-            file_id,
-        };
-        results.push(DocumentGroup { representative, members: vec![] });
-    }
+    let candidates = file_order
+        .into_iter()
+        .take(total_limit)
+        .flat_map(|fid| file_hits.remove(&fid).unwrap_or_default())
+        .collect();
 
-    Ok((total, results))
+    Ok((candidates, truncated_ids))
 }
 
 /// Fetch duplicate paths grouped by file ID.
@@ -799,11 +917,10 @@ mod tests {
         let refs: Vec<(usize, &str)> = owned.iter().map(|(n, s)| (*n, s.as_str())).collect();
         insert_inline_file(&conn, "dense.txt", 1000, "text", &refs);
 
-        // One-token query → per_file_cap = 1.
+        // One-token query → per_file_cap = 1, so only one row collected per file → no members.
         let (_total, groups) = document_candidates(&conn, "keyword", 100, DateFilter::default()).unwrap();
         assert_eq!(groups.len(), 1, "should return exactly one group for the file");
-        // The group has no members because members is always empty in current impl.
-        assert!(groups[0].members.is_empty());
+        assert!(groups[0].members.is_empty(), "single-token query has per_file_cap=1, so no members");
     }
 
     #[test]

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -11,7 +11,7 @@ use tokio::task::spawn_blocking;
 use find_common::api::{ContextLine, FileKind, SearchMode, SearchResponse, SearchResult};
 
 use crate::fuzzy::FuzzyScorer;
-use crate::{db, db::search::{CandidateRow, DocumentGroup}, db::DateFilter, AppState};
+use crate::{db, db::search::CandidateRow, db::DateFilter, AppState};
 
 /// A scored search result paired with its `file_id` for alias lookup.
 struct ScoredResult {
@@ -183,6 +183,7 @@ fn make_result(
         context_lines: vec![],
         duplicate_paths: vec![],
         extra_matches,
+        hits_truncated: false,
     }
 }
 
@@ -286,25 +287,52 @@ pub async fn search(
                 // Document-family modes: one result per file.
                 match mode {
                     SearchMode::Document => {
-                        let (doc_total, candidates) = db::document_candidates(&conn, &query, scoring_limit, date_filter)?;
+                        // Qualify: files containing ALL tokens.
+                        let qualifying_ids = db::document_qualifying_ids(&conn, &query, date_filter)?;
+                        let doc_total = qualifying_ids.len();
+                        if qualifying_ids.is_empty() {
+                            return Ok((0, vec![]));
+                        }
+                        let Some(or_expr) = db::build_doc_or_expr(&query) else {
+                            return Ok((0, vec![]));
+                        };
+
+                        // Fetch all lines matching any token, capped at 20 per file.
+                        const MAX_LINES_PER_FILE: usize = 20;
+                        let (candidates, truncated_ids) = db::document_all_lines(
+                            &conn, &qualifying_ids, &or_expr, MAX_LINES_PER_FILE, scoring_limit,
+                        )?;
+
+                        // Batch-fetch content for all candidate lines.
+                        let pairs: Vec<(i64, i64)> = candidates.iter()
+                            .map(|c| (c.file_id, c.line_number as i64))
+                            .collect();
+                        let content_map = db::read_content_batch(&conn, cs.as_ref(), &pairs);
+
                         let mut scorer = FuzzyScorer::new(&query, case_sensitive);
                         let result_pairs: Vec<ScoredResult> = candidates
                             .into_iter()
-                            .map(|DocumentGroup { representative: rep, members: extras }| {
-                                let file_id = rep.file_id;
-                                let score = scorer.score(&rep.content).unwrap_or(1);
-                                let extra_matches = extras.into_iter()
-                                    .map(|e| ContextLine { line_number: e.line_number, content: e.content })
-                                    .collect();
-                                ScoredResult { result: make_result(&source_name, &rep, score, extra_matches), file_id }
+                            .map(|mut c| {
+                                let file_id = c.file_id;
+                                if let Some(content) = content_map.get(&(file_id, c.line_number as i64)) {
+                                    c.content = content.clone();
+                                }
+                                let score = scorer.score(&c.content).unwrap_or(1);
+                                ScoredResult { result: make_result(&source_name, &c, score, vec![]), file_id }
                             })
                             .collect();
+
                         let file_ids: Vec<i64> = result_pairs.iter().map(|sr| sr.file_id).collect();
                         let dups_map = db::fetch_duplicates_for_file_ids(&conn, &file_ids)?;
                         let results: Vec<SearchResult> = result_pairs
                             .into_iter()
                             .map(|mut sr| {
-                                if let Some(dups) = dups_map.get(&sr.file_id) { sr.result.duplicate_paths = dups.clone(); }
+                                if let Some(dups) = dups_map.get(&sr.file_id) {
+                                    sr.result.duplicate_paths = dups.clone();
+                                }
+                                if truncated_ids.contains(&(sr.file_id)) {
+                                    sr.result.hits_truncated = true;
+                                }
                                 sr.result
                             })
                             .collect();

--- a/crates/server/tests/search_modes.rs
+++ b/crates/server/tests/search_modes.rs
@@ -211,6 +211,33 @@ async fn test_document_mode_groups_by_file() {
 }
 
 #[tokio::test]
+async fn test_document_mode_multi_keyword_all_lines() {
+    let srv = TestServer::spawn().await;
+    // Each keyword is on a separate line so they produce distinct FTS candidate rows.
+    srv.post_bulk(&make_text_bulk("docs", "keywords.txt",
+        "line with alpha here\nsome other content\nline with bravo here")).await;
+    srv.wait_for_idle().await;
+
+    let resp: SearchResponse = srv
+        .client
+        .get(srv.url("/api/v1/search?q=alpha+bravo&mode=document&source=docs"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert!(resp.total >= 1, "document mode should find the file");
+    // Document mode now returns one SearchResult per matching line.
+    let file_results: Vec<_> = resp.results.iter().filter(|r| r.path == "keywords.txt").collect();
+    assert!(file_results.len() >= 2, "should have at least 2 results for keywords.txt (one per keyword line)");
+    let all_snippets: Vec<&str> = file_results.iter().map(|r| r.snippet.as_str()).collect();
+    assert!(all_snippets.iter().any(|s| s.contains("alpha")), "alpha should appear in some result snippet");
+    assert!(all_snippets.iter().any(|s| s.contains("bravo")), "bravo should appear in some result snippet");
+}
+
+#[tokio::test]
 async fn test_doc_exact_mode_matches_phrase() {
     let srv = TestServer::spawn().await;
     srv.post_bulk(&make_text_bulk("docs", "phrase.txt", "the exact phrase to find here")).await;

--- a/install.sh
+++ b/install.sh
@@ -261,8 +261,9 @@ path = "$DIR_ESC"
 [scan]
 # max_content_size_mb = 10   # Skip files larger than this (MB)
 # max_line_length  = 120    # Wrap long lines at this column (0 = disable)
-# follow_symlinks  = false
-# include_hidden   = false  # Index dot-files and dot-directories
+# follow_symlinks    = false
+# cross_filesystems  = false  # Set to true to traverse mount points and external volumes
+# include_hidden     = false  # Index dot-files and dot-directories
 # Extra glob patterns to skip, added to the built-in defaults.
 # Use exclude = [...] instead to replace the defaults entirely.
 # exclude_extra = []

--- a/packaging/windows/find-anything.iss
+++ b/packaging/windows/find-anything.iss
@@ -262,8 +262,9 @@ begin
     '[scan]' + NL +
     '# max_content_size_mb = 10   # Skip files larger than this (MB)' + NL +
     '# max_line_length  = 120  # Wrap long lines at this column (0 = disable)' + NL +
-    '# follow_symlinks  = false' + NL +
-    '# include_hidden   = false  # Index dot-files and dot-directories' + NL +
+    '# follow_symlinks    = false' + NL +
+    '# cross_filesystems  = false  # Set to true to traverse mount points and external volumes' + NL +
+    '# include_hidden     = false  # Index dot-files and dot-directories' + NL +
     '# Extra glob patterns to skip, added to the built-in defaults.' + NL +
     '# Use exclude = [...] instead to replace the defaults entirely.' + NL +
     '# exclude_extra = []' + NL +

--- a/web/src/lib/ResultList.svelte
+++ b/web/src/lib/ResultList.svelte
@@ -24,6 +24,10 @@
 			}
 			map.get(key)!.hits.push(r);
 		}
+		// Sort hits within each file card by line number so navigation is sequential.
+		for (const group of map.values()) {
+			group.hits.sort((a, b) => a.line_number - b.line_number);
+		}
 		return order.map((k) => map.get(k)!);
 	})();
 </script>

--- a/web/src/lib/SearchResult.svelte
+++ b/web/src/lib/SearchResult.svelte
@@ -226,7 +226,7 @@
 			{:else if hits.length > 1}
 				<!-- svelte-ignore a11y-no-static-element-interactions -->
 				<!-- svelte-ignore a11y-click-events-have-key-events -->
-				<span class="hit-nav" title="{activeHitIndex + 1} of {hits.length} hits" on:click|stopPropagation>
+				<span class="hit-nav" title="{activeHitIndex + 1} of {hits.length}{hits[0].hits_truncated ? '+' : ''} hits" on:click|stopPropagation>
 					<button class="hit-nav-btn" class:hit-nav-hidden={activeHitIndex === 0} on:click|stopPropagation={() => switchToHit(activeHitIndex - 1)} title="Previous hit (line {displayLine(hits[activeHitIndex - 1]?.line_number ?? 0)})">
 						<IconChevronLeft />
 					</button>
@@ -234,6 +234,9 @@
 					<button class="hit-nav-btn" class:hit-nav-hidden={activeHitIndex >= hits.length - 1} on:click|stopPropagation={() => switchToHit(activeHitIndex + 1)} title="Next hit (line {displayLine(hits[activeHitIndex + 1]?.line_number ?? 0)})">
 						<IconChevronRight />
 					</button>
+					{#if hits[0].hits_truncated}
+						<span class="truncated-badge" title="More than {hits.length} matches in this file">+</span>
+					{/if}
 				</span>
 			{/if}
 		</div>
@@ -443,6 +446,15 @@
 	.hit-nav-hidden {
 		visibility: hidden;
 		pointer-events: none;
+	}
+
+	.truncated-badge {
+		padding: 0 4px;
+		font-size: 11px;
+		color: var(--text-dim);
+		border-left: 1px solid var(--border);
+		line-height: 20px;
+		cursor: default;
 	}
 
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -26,6 +26,8 @@ export interface SearchResult {
 	duplicate_paths?: string[];
 	/** Additional lines where query terms were found (document mode only). */
 	extra_matches?: ContextLine[];
+	/** True when this file had more matching lines than the display cap (document mode only). */
+	hits_truncated?: boolean;
 }
 
 export interface SearchResponse {


### PR DESCRIPTION
## Summary

- **`cross_filesystems` config option** — `[scan] cross_filesystems = false` (default) prevents the walker from crossing mount points (backup volumes, network shares, bind mounts). Set to `true` to restore old behaviour.
- **Document mode shows all matching lines** — `doc:` search now returns one result per matching line for each qualifying file (any keyword), rather than a single representative. Capped at 20 lines per file with a `+` overflow badge. Hits are sorted by line number and navigable via chevrons in the result card.

## Test plan

- [ ] `cross_filesystems = false` (default): scan stops at mount points; no cross-device directories indexed
- [ ] `cross_filesystems = true`: scan crosses mount points as before
- [ ] `doc: foo bar` — qualifying files show individual hits for each line containing "foo" or "bar", navigable with chevrons
- [ ] Files with >20 matching lines show a `+` badge in the hit counter
- [ ] Hit navigation is in ascending line-number order (not rank order)
- [ ] `cargo test --test search_modes` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)