### PR TITLE
fix: run integration tests sequentially to prevent CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: cargo test --workspace --lib -- --test-threads=1
 
       - name: Test (integration)
-        run: cargo test --workspace --tests
+        run: cargo test --workspace --tests -- --test-threads=1
 
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings

--- a/crates/server/tests/helpers/mod.rs
+++ b/crates/server/tests/helpers/mod.rs
@@ -79,7 +79,7 @@ impl TestServer {
     /// next (during which counts are briefly 0 even though more work is pending).
     /// Panics after 30 seconds.
     pub async fn wait_for_idle(&self) {
-        let deadline = Instant::now() + Duration::from_secs(30);
+        let deadline = Instant::now() + Duration::from_secs(60);
         let mut consecutive_idle = 0u32;
         loop {
             let resp: StatsResponse = self
@@ -101,7 +101,7 @@ impl TestServer {
                 consecutive_idle = 0;
             }
             if Instant::now() >= deadline {
-                panic!("worker did not become idle within 30s (inbox_pending={}, archive_queue={})",
+                panic!("worker did not become idle within 60s (inbox_pending={}, archive_queue={})",
                     resp.inbox_pending, resp.archive_queue);
             }
             tokio::time::sleep(Duration::from_millis(50)).await;


### PR DESCRIPTION
## Summary

- Run integration tests with `--test-threads=1` so each `TestServer` runs in isolation, eliminating cross-test contention on the blocking thread pool
- Increase `wait_for_idle` deadline from 30s to 60s to give headroom on slow runners

## Root cause

The post-merge CI run hit the 30-minute job limit with 4 `stats_cache` integration tests stuck for 25 minutes. Under CI load, multiple parallel `TestServer` instances all spawn `spawn_blocking` tasks (Phase 1, archive batch, `full_rebuild`), saturating the pool. The archive worker's 5-second sleep + delayed `full_rebuild` kept `archive_queue > 0` past the 30-second `wait_for_idle` deadline, causing tests to fail, new tests to start, hit the same problem, and repeat until the job limit was reached.

The fix is orthogonal to the `inbox-circuit-breaker` changes — parallel integration tests were always latently flaky under load; this just manifested here.

## Test plan

- [ ] CI passes within the 30-minute limit
- [ ] `cargo test --workspace --tests -- --test-threads=1` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)