### PR TITLE
Release 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+---
+
+## [0.7.4] - 2026-04-23
+
 ### Added
 
 - **`[log] dir` config option** — when set, find-watch writes daily rotating log files (`find-watch.log.YYYY-MM-DD`) to the specified directory in addition to stdout; spawned find-scan processes also redirect their stdout/stderr to `find-scan.log.YYYY-MM-DD` in the same directory. Useful when running as a Windows service where stdout is not captured. Directory is created automatically.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "find-client"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "find-common"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "find-content-store"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "find-common",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-archive"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dicom"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "dicom-dictionary-std",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dispatch"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "find-extract-dicom",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-epub"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-html"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-media"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-office"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "calamine",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pdf"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pe"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-text"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "content_inspector",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "find-handler"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "url",
 ]
@@ -1718,7 +1718,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "find-preview-dicom"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "dicom-object",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "find-server"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-client"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [[bin]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-common"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [dependencies]

--- a/crates/content-store/Cargo.toml
+++ b/crates/content-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-content-store"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/archive/Cargo.toml
+++ b/crates/extractors/archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-archive"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dicom/Cargo.toml
+++ b/crates/extractors/dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dicom"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dispatch/Cargo.toml
+++ b/crates/extractors/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dispatch"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/epub/Cargo.toml
+++ b/crates/extractors/epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-epub"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/html/Cargo.toml
+++ b/crates/extractors/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-html"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/media/Cargo.toml
+++ b/crates/extractors/media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-media"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/office/Cargo.toml
+++ b/crates/extractors/office/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-office"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pdf/Cargo.toml
+++ b/crates/extractors/pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pdf"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pe/Cargo.toml
+++ b/crates/extractors/pe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pe"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/text/Cargo.toml
+++ b/crates/extractors/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-text"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-handler"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [[bin]]

--- a/crates/preview-dicom/Cargo.toml
+++ b/crates/preview-dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-preview-dicom"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [[bin]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-server"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Bump version to 0.7.4 and update CHANGELOG.

## Summary

- File logging for find-watch/find-scan (daily rotating log files)
- SQLite page cache limits (blobs.db and source DBs capped at 16 MB)
- Fix spurious mass reindex on Windows directory Modify events
- `no_wrap_extensions` config — exempt file types from server-side word-wrap; formatter-matched extensions automatically exempt
- Pre-existing clippy lint fixes (collapsible_match, sort_by_key)