### PR TITLE
Release 0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+---
+
+## [0.7.5] - 2026-04-24
+
 ### Added
 
 - **HTML viewer** — `.html` and `.htm` files now show a "Rendered" toolbar button that renders the file in an inline iframe. A new path-based raw endpoint (`GET /api/v1/raw/{source}/{*path}`) is used so that relative assets (images, CSS) resolve correctly as sibling requests on the same endpoint.

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-client"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [[bin]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-common"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [dependencies]

--- a/crates/content-store/Cargo.toml
+++ b/crates/content-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-content-store"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/archive/Cargo.toml
+++ b/crates/extractors/archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-archive"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dicom/Cargo.toml
+++ b/crates/extractors/dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dicom"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dispatch/Cargo.toml
+++ b/crates/extractors/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dispatch"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/epub/Cargo.toml
+++ b/crates/extractors/epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-epub"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/html/Cargo.toml
+++ b/crates/extractors/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-html"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/media/Cargo.toml
+++ b/crates/extractors/media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-media"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/office/Cargo.toml
+++ b/crates/extractors/office/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-office"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pdf/Cargo.toml
+++ b/crates/extractors/pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pdf"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pe/Cargo.toml
+++ b/crates/extractors/pe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pe"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/text/Cargo.toml
+++ b/crates/extractors/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-text"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [lib]

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-handler"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [[bin]]

--- a/crates/preview-dicom/Cargo.toml
+++ b/crates/preview-dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-preview-dicom"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [[bin]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-server"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Bumps version to 0.7.5 and moves the HTML viewer entry from `[Unreleased]` to `[0.7.5]` in CHANGELOG.

## Changes in this release

- HTML viewer for `.html`/`.htm` files with rendered iframe
- Path-based raw endpoint (`GET /api/v1/raw/{source}/{*path}`) for correct relative asset resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)