### PR TITLE
Release 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+---
+
+## [0.7.6] - 2026-04-27
+
 ### Changed
 
 - **Formatted view default** — markdown, RTF, and HTML files now open in formatted/rendered view by default when navigated to directly (from the tree, command palette, or a direct link with no line selection). The three separate per-format profile flags (`markdownFormat`, `rtfFormat`, `htmlFormat`) have been consolidated into a single `showFormatted` preference.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "find-client"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "find-common"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "find-content-store"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "find-common",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-archive"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dicom"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "dicom-dictionary-std",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dispatch"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "find-extract-dicom",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-epub"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-html"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-media"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-office"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "calamine",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pdf"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pe"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-text"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "content_inspector",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "find-handler"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "url",
 ]
@@ -1669,7 +1669,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "find-preview-dicom"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "dicom-object",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "find-server"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-client"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [[bin]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-common"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [dependencies]

--- a/crates/content-store/Cargo.toml
+++ b/crates/content-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-content-store"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/archive/Cargo.toml
+++ b/crates/extractors/archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-archive"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dicom/Cargo.toml
+++ b/crates/extractors/dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dicom"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dispatch/Cargo.toml
+++ b/crates/extractors/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dispatch"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/epub/Cargo.toml
+++ b/crates/extractors/epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-epub"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/html/Cargo.toml
+++ b/crates/extractors/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-html"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/media/Cargo.toml
+++ b/crates/extractors/media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-media"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/office/Cargo.toml
+++ b/crates/extractors/office/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-office"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pdf/Cargo.toml
+++ b/crates/extractors/pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pdf"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pe/Cargo.toml
+++ b/crates/extractors/pe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pe"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/text/Cargo.toml
+++ b/crates/extractors/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-text"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-handler"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [[bin]]

--- a/crates/preview-dicom/Cargo.toml
+++ b/crates/preview-dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-preview-dicom"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [[bin]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-server"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Release 0.7.6

### Changed

- **Formatted view default** — markdown, RTF, and HTML files now open in formatted/rendered view by default when navigated to directly (from the tree, command palette, or a direct link with no line selection). The three separate per-format profile flags (`markdownFormat`, `rtfFormat`, `htmlFormat`) have been consolidated into a single `showFormatted` preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)