### PR TITLE
chore: bump TypeScript 5.9 -> 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Changed
 
-- **Web toolchain upgrade (Phase 1)** — bumped `svelte` 4 → 5, `vite` 5 → 8, `@sveltejs/vite-plugin-svelte` 3 → 7, `svelte-check` 3 → 4, `vitest` 4.0 → 4.1. Existing components are untouched (Svelte 5 runs legacy-syntax components unmodified); this is purely a toolchain bump. TypeScript stays at 5.x for now as a separate follow-up. Fixed three new Svelte 5 compiler warnings (a11y `tabindex` on a dialog role, two self-closing non-void elements) and restored the rtf.js chunk-size-warning suppression, which Vite 8's new default Rolldown bundler reports through a different path than the old `rollupOptions.onwarn` hook.
+- **Web toolchain upgrade (Phase 1)** — bumped `svelte` 4 → 5, `vite` 5 → 8, `@sveltejs/vite-plugin-svelte` 3 → 7, `svelte-check` 3 → 4, `vitest` 4.0 → 4.1. Existing components are untouched (Svelte 5 runs legacy-syntax components unmodified); this is purely a toolchain bump. Fixed three new Svelte 5 compiler warnings (a11y `tabindex` on a dialog role, two self-closing non-void elements) and restored the rtf.js chunk-size-warning suppression, which Vite 8's new default Rolldown bundler reports through a different path than the old `rollupOptions.onwarn` hook.
+- **TypeScript 6** — bumped `typescript` 5.9 → 6.0 as a follow-up to the toolchain upgrade above. No code changes needed: the project's `tsconfig.json` already set `strict`, `module`/`target`, `moduleResolution`, and `esModuleInterop` explicitly to values matching TS 6's new defaults.
 - **Dependency housekeeping** — `cargo update` across the Rust workspace (~100 transitive crates moved forward within existing semver ranges); `chrono-node` and `marked` bumped within range on the web side.
 
 ### Fixed

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "svelte": "^5.56.4",
     "svelte-check": "^4.7.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.1.3",
     "vitest": "^4.1.10"
   },

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -26,10 +26,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@5.9.3)(vite@8.1.3))
+        version: 3.0.10(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@6.0.3)(vite@8.1.3))
       '@sveltejs/kit':
         specifier: ^2.69.1
-        version: 2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@5.9.3)(vite@8.1.3)
+        version: 2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@6.0.3)(vite@8.1.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
         version: 7.1.2(svelte@5.56.4)(vite@8.1.3)
@@ -38,10 +38,10 @@ importers:
         version: 5.56.4
       svelte-check:
         specifier: ^4.7.1
-        version: 4.7.1(picomatch@4.0.5)(svelte@5.56.4)(typescript@5.9.3)
+        version: 4.7.1(picomatch@4.0.5)(svelte@5.56.4)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.1.3
         version: 8.1.3
@@ -639,8 +639,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -897,11 +897,11 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@5.9.3)(vite@8.1.3))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@6.0.3)(vite@8.1.3))':
     dependencies:
-      '@sveltejs/kit': 2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@5.9.3)(vite@8.1.3)
+      '@sveltejs/kit': 2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@6.0.3)(vite@8.1.3)
 
-  '@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@5.9.3)(vite@8.1.3)':
+  '@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3))(svelte@5.56.4)(typescript@6.0.3)(vite@8.1.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
@@ -919,7 +919,7 @@ snapshots:
       svelte: 5.56.4
       vite: 8.1.3
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@sveltejs/load-config@0.2.0': {}
 
@@ -1178,7 +1178,7 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  svelte-check@4.7.1(picomatch@4.0.5)(svelte@5.56.4)(typescript@5.9.3):
+  svelte-check@4.7.1(picomatch@4.0.5)(svelte@5.56.4)(typescript@6.0.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       '@sveltejs/load-config': 0.2.0
@@ -1187,7 +1187,7 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.56.4
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - picomatch
 
@@ -1228,7 +1228,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   vite@8.1.3:
     dependencies:


### PR DESCRIPTION
## Summary

Follow-up to the Svelte 5/Vite 8 toolchain bump (#38), deliberately kept as its own isolated PR since TypeScript 6's new defaults are an independent breaking-change surface from Svelte/Vite:

- `strict` mode now defaults to `true`
- `module` defaults to `esnext`, `target` defaults to `es2025`
- `rootDir` defaults to the tsconfig.json's own directory
- `types` defaults to `[]` instead of auto-discovering `node_modules/@types`
- Several compiler options deprecated (`--target es5`, `--moduleResolution node`/`classic`, `--module amd/umd/systemjs/none`, `--outFile`, etc.)

**No code changes were needed.** This project's `tsconfig.json` already explicitly sets `strict: true`, `module`/`target: "esnext"`, `moduleResolution: "bundler"`, and `esModuleInterop: true` — all matching TS 6's new defaults — so none of the above actually changed behavior here.

## Test plan

- [x] `pnpm run check` — 0 errors, 0 warnings
- [x] `pnpm run build` — clean
- [x] `pnpm run test` — 199/199 passing
- Skipped a browser smoke test: this is a compile-time-only change (TypeScript version doesn't affect the emitted JS), so typecheck/build/test fully cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)