### PR TITLE
chore: migrate MobilePanel.svelte to Svelte 5 runes (1/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Changed
+
+- **Svelte runes migration (incremental, 1/N)** — `MobilePanel.svelte` converted from legacy syntax (`export let`, `<slot>`) to runes (`$props()`, `$bindable()`, snippet `children`). Purely internal; its one call site (`TopBar.svelte`) needed no changes since `bind:` and slotted-content syntax are unchanged from the caller's perspective. Part of the incremental, file-by-file migration following the Svelte 5 toolchain bump.
+
 ### Added
 
 - **PDF viewer on mobile** — Android Chrome previously triggered a file download instead of displaying PDFs inline. PDF.js is now used on Android to render PDF pages as canvas elements directly in the browser. The existing iframe viewer is unchanged on desktop. PDF.js is loaded lazily via dynamic import, only on first PDF view.

--- a/web/src/lib/MobilePanel.svelte
+++ b/web/src/lib/MobilePanel.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import IconBack from '$lib/icons/IconBack.svelte';
-	export let open = false;
-	export let title: string;
+
+	let {
+		open = $bindable(false),
+		title,
+		children
+	}: { open?: boolean; title: string; children?: Snippet } = $props();
 
 	// Portal: physically moves the panel DOM node to document.body so it is
 	// never clipped or hidden by any ancestor's overflow/display/transform CSS.
@@ -14,13 +19,13 @@
 {#if open}
 	<div class="mobile-panel" use:portal>
 		<div class="mobile-panel-header">
-			<button class="back-btn" on:click={() => (open = false)} aria-label="Close">
+			<button class="back-btn" onclick={() => (open = false)} aria-label="Close">
 				<IconBack />
 			</button>
 			<span class="mobile-panel-title">{title}</span>
 		</div>
 		<div class="mobile-panel-body">
-			<slot />
+			{@render children?.()}
 		</div>
 	</div>
 {/if}


### PR DESCRIPTION
## Summary

First step of the incremental Svelte runes migration, following the Svelte 5 toolchain bump (#38). This is intentionally file-by-file rather than a bulk rewrite — Svelte 5 fully supports mixing legacy and rune components in the same app.

`MobilePanel.svelte` was picked as the starting point: small (78 lines), single call site (`TopBar.svelte`), and it exercises two of the four major legacy→runes conversions in one low-risk file:

- `export let open`/`title` → `$props()` destructuring
- `open` (two-way bound by the caller via `bind:open`) → `$bindable(false)`
- `<slot />` → a `children: Snippet` prop rendered via `{@render children?.()}`
- `on:click` → `onclick` (Svelte 5 flags the old event directive as deprecated once a component uses runes)

**No caller changes needed** — `bind:open` and slotted-content syntax at the `TopBar.svelte` call site are identical regardless of whether the child component uses legacy or runes mode internally.

## Test plan

- [x] `pnpm run check` — 0 errors/warnings
- [x] `pnpm run build` — clean
- [x] `pnpm run test` — 199/199 passing
- [x] Live-tested with Playwright at a mobile viewport (400px): clicking the Search Help trigger renders the panel (computed `display: flex`, correct title, real `SearchHelpContent` text rendered through the snippet), and the back button's `onclick` correctly propagates through `$bindable` to close it (panel unmounts)
- [x] Manually verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)