### PR TITLE
chore: migrate Group 2 (simple standalone panels) to Svelte 5 runes (2/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Changed
 
 - **Svelte runes migration (incremental, 1/N)** — `MobilePanel.svelte` converted from legacy syntax (`export let`, `<slot>`) to runes (`$props()`, `$bindable()`, snippet `children`). Purely internal; its one call site (`TopBar.svelte`) needed no changes since `bind:` and slotted-content syntax are unchanged from the caller's perspective. Part of the incremental, file-by-file migration following the Svelte 5 toolchain bump.
+- **Svelte runes migration (incremental, 2/N)** — `About`, `AdminPanel`, `AudioViewer`, `DirectoryTree`, `MarkdownViewer`, `MetaDrawer`, `Preferences`, `StatsPanel`, `VideoViewer` converted from legacy syntax to runes (`$state`, `$derived`, `$props()`, `onclick`/`onchange` instead of `on:click`/`on:change`). All 22 icon components and `SearchHelpContent`/`AppLogo` needed no changes — they have no `<script>` block at all. No caller changes needed anywhere in this group.
 
 ### Added
 

--- a/web/src/lib/About.svelte
+++ b/web/src/lib/About.svelte
@@ -2,17 +2,17 @@
 	import { getSettings, getUpdateCheck, applyUpdate } from '$lib/api';
 	import { onMount } from 'svelte';
 
-	let serverVersion = '';
-	let buildHash = '';
+	let serverVersion = $state('');
+	let buildHash = $state('');
 
 	type CheckState = 'idle' | 'checking' | 'up-to-date' | 'update-available' | 'no-systemd' | 'no-asset' | 'error';
-	let checkState: CheckState = 'idle';
-	let latestVersion = '';
-	let errorMsg = '';
+	let checkState: CheckState = $state('idle');
+	let latestVersion = $state('');
+	let errorMsg = $state('');
 
 	type ApplyState = 'idle' | 'applying' | 'restarting' | 'done' | 'error';
-	let applyState: ApplyState = 'idle';
-	let applyMsg = '';
+	let applyState: ApplyState = $state('idle');
+	let applyMsg = $state('');
 
 	onMount(async () => {
 		try {
@@ -82,7 +82,7 @@
 
 	<div class="update-row">
 		{#if applyState === 'idle' || applyState === 'error'}
-			<button class="check-btn" on:click={checkForUpdates} disabled={checkState === 'checking'}>
+			<button class="check-btn" onclick={checkForUpdates} disabled={checkState === 'checking'}>
 				{checkState === 'checking' ? 'Checking…' : 'Check for updates'}
 			</button>
 		{/if}
@@ -91,7 +91,7 @@
 			<span class="status ok">Up to date (v{latestVersion})</span>
 		{:else if checkState === 'update-available' && applyState === 'idle'}
 			<span class="status update">v{latestVersion} available</span>
-			<button class="apply-btn" on:click={doUpdate}>Update &amp; restart</button>
+			<button class="apply-btn" onclick={doUpdate}>Update &amp; restart</button>
 		{:else if checkState === 'update-available' && applyState === 'applying'}
 			<span class="status update">Downloading v{latestVersion}…</span>
 		{:else if applyState === 'restarting'}

--- a/web/src/lib/AdminPanel.svelte
+++ b/web/src/lib/AdminPanel.svelte
@@ -3,11 +3,11 @@
 	import { getInboxStatus, retryFailedInbox } from '$lib/api';
 	import type { InboxStatusResponse } from '$lib/api';
 
-	let inbox: InboxStatusResponse | null = null;
-	let loading = true;
-	let error: string | null = null;
-	let retrying = false;
-	let retryMessage: string | null = null;
+	let inbox: InboxStatusResponse | null = $state(null);
+	let loading = $state(true);
+	let error: string | null = $state(null);
+	let retrying = $state(false);
+	let retryMessage: string | null = $state(null);
 
 	onMount(() => {
 		fetchStatus();
@@ -56,7 +56,7 @@
 		</div>
 		{#if inbox.failed.length > 0}
 			<div class="actions">
-				<button class="btn" on:click={handleRetry} disabled={retrying}>
+				<button class="btn" onclick={handleRetry} disabled={retrying}>
 					{retrying ? 'Retrying…' : 'Retry Failed'}
 				</button>
 			</div>

--- a/web/src/lib/AudioViewer.svelte
+++ b/web/src/lib/AudioViewer.svelte
@@ -2,15 +2,20 @@
 	import { parseMetaTags } from '$lib/metaTags';
 	import MetaDrawer from '$lib/MetaDrawer.svelte';
 
-	/** URL to stream the audio file. */
-	export let src: string;
-	/** Extracted metadata lines (line_number === 1, starting with '['). */
-	export let metaLines: { content: string }[] = [];
+	let {
+		src,
+		metaLines = []
+	}: {
+		/** URL to stream the audio file. */
+		src: string;
+		/** Extracted metadata lines (line_number === 1, starting with '['). */
+		metaLines?: { content: string }[];
+	} = $props();
 </script>
 
 <div class="audio-split-panel">
 	<div class="audio-split-left">
-		<!-- svelte-ignore a11y-media-has-caption -->
+		<!-- svelte-ignore a11y_media_has_caption -->
 		<audio controls {src} class="audio-player">
 			Your browser does not support the audio element.
 		</audio>

--- a/web/src/lib/DirectoryTree.svelte
+++ b/web/src/lib/DirectoryTree.svelte
@@ -6,13 +6,18 @@
 	import { liveEvent } from '$lib/liveUpdates';
 	import { getCachedDir, prefetchTreePath } from '$lib/treeCache';
 
-	export let source: string;
-	/** Currently open file path — highlighted in the tree. */
-	export let activePath: string | null = null;
+	let {
+		source,
+		activePath = null
+	}: {
+		source: string;
+		/** Currently open file path — highlighted in the tree. */
+		activePath?: string | null;
+	} = $props();
 
-	let roots: DirEntry[] = [];
-	let loading = true;
-	let error: string | null = null;
+	let roots: DirEntry[] = $state([]);
+	let loading = $state(true);
+	let error: string | null = $state(null);
 
 	onMount(async () => {
 		try {
@@ -35,14 +40,16 @@
 	});
 
 	// Refresh roots when a file at the root level is added, removed, or renamed.
-	$: if ($liveEvent && $liveEvent.source === source && !loading) {
-		const ev = $liveEvent;
-		const parentDir = dirOf(ev.path);
-		const newParentDir = ev.new_path ? dirOf(ev.new_path) : null;
-		if (parentDir === '' || newParentDir === '') {
-			refreshRoots();
+	$effect(() => {
+		if ($liveEvent && $liveEvent.source === source && !loading) {
+			const ev = $liveEvent;
+			const parentDir = dirOf(ev.path);
+			const newParentDir = ev.new_path ? dirOf(ev.new_path) : null;
+			if (parentDir === '' || newParentDir === '') {
+				refreshRoots();
+			}
 		}
-	}
+	});
 
 	async function refreshRoots() {
 		try {

--- a/web/src/lib/MarkdownViewer.svelte
+++ b/web/src/lib/MarkdownViewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	/** Pre-rendered HTML string from marked.parse(). */
-	export let rendered: string;
+	let { rendered }: { rendered: string } = $props();
 </script>
 
 <div class="markdown-content">

--- a/web/src/lib/MetaDrawer.svelte
+++ b/web/src/lib/MetaDrawer.svelte
@@ -1,14 +1,24 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import IconMetaOpen from '$lib/icons/IconMetaOpen.svelte';
 	import IconMetaClose from '$lib/icons/IconMetaClose.svelte';
-	/** Whether the drawer starts open. */
-	export let initialOpen: boolean = false;
 
-	let open = initialOpen;
+	let {
+		initialOpen = false,
+		children
+	}: {
+		/** Whether the drawer starts open. */
+		initialOpen?: boolean;
+		children?: Snippet;
+	} = $props();
+
+	// Intentionally a one-time snapshot, not synced to the prop afterward — the
+	// drawer's open/closed state is then controlled entirely by the toggle button.
+	let open = $state(initialOpen);
 </script>
 
 <div class="meta-drawer">
-	<button class="drawer-toggle" on:click={() => (open = !open)} title={open ? 'Hide metadata' : 'Show metadata'}>
+	<button class="drawer-toggle" onclick={() => (open = !open)} title={open ? 'Hide metadata' : 'Show metadata'}>
 		{#if open}
 			<IconMetaOpen />
 		{:else}
@@ -17,7 +27,7 @@
 	</button>
 	<div class="drawer-content drawer-always-open" class:drawer-open={open}>
 		<div class="drawer-inner">
-			<slot />
+			{@render children?.()}
 		</div>
 	</div>
 </div>

--- a/web/src/lib/Preferences.svelte
+++ b/web/src/lib/Preferences.svelte
@@ -6,7 +6,7 @@
 
 	const HANDLER_INSTALL_CMD =
 		'irm https://github.com/jamietre/find-anything/releases/latest/download/install-handler.ps1 | iex';
-	let handlerCopied = false;
+	let handlerCopied = $state(false);
 	function copyHandlerCmd() {
 		navigator.clipboard.writeText(HANDLER_INSTALL_CMD).then(() => {
 			handlerCopied = true;
@@ -18,7 +18,7 @@
 		profile.update((p) => ({ ...p, handlerInstalled: value || undefined }));
 	}
 
-	let sourceNames: string[] = [];
+	let sourceNames: string[] = $state([]);
 
 	onMount(async () => {
 		try {
@@ -57,7 +57,7 @@
 			id="theme"
 			class="select"
 			value={$profile.theme ?? 'dark'}
-			on:change={(e) => setTheme(e.currentTarget.value)}
+			onchange={(e) => setTheme(e.currentTarget.value)}
 		>
 			<option value="dark">Dark</option>
 			<option value="light">Light</option>
@@ -74,7 +74,7 @@
 			id="tab-width"
 			class="select"
 			value={$profile.tabWidth ?? $tabWidth}
-			on:change={(e) => setTabWidth(Number(e.currentTarget.value))}
+			onchange={(e) => setTabWidth(Number(e.currentTarget.value))}
 		>
 			<option value={1}>1</option>
 			<option value={2}>2</option>
@@ -82,7 +82,7 @@
 			<option value={8}>8</option>
 		</select>
 		{#if $profile.tabWidth !== undefined}
-			<button class="clear-btn" on:click={() => { profile.update(p => { const {tabWidth: _, ...rest} = p; return rest; }); tabWidth.set(4); }}>Reset</button>
+			<button class="clear-btn" onclick={() => { profile.update(p => { const {tabWidth: _, ...rest} = p; return rest; }); tabWidth.set(4); }}>Reset</button>
 		{/if}
 	</div>
 </div>
@@ -95,7 +95,7 @@
 			id="ctx-window"
 			class="select"
 			value={$profile.contextWindow ?? $contextWindow}
-			on:change={(e) => setContextWindow(Number(e.currentTarget.value))}
+			onchange={(e) => setContextWindow(Number(e.currentTarget.value))}
 		>
 			<option value={0}>0 (match only)</option>
 			<option value={1}>1 (±1 line)</option>
@@ -104,7 +104,7 @@
 			<option value={5}>5 (±5 lines)</option>
 		</select>
 		{#if $profile.contextWindow !== undefined}
-			<button class="clear-btn" on:click={() => { profile.update(p => { const {contextWindow: _, ...rest} = p; return rest; }); contextWindow.set(1); }}>Reset</button>
+			<button class="clear-btn" onclick={() => { profile.update(p => { const {contextWindow: _, ...rest} = p; return rest; }); contextWindow.set(1); }}>Reset</button>
 		{/if}
 	</div>
 </div>
@@ -118,7 +118,7 @@
 </div>
 <div class="handler-row">
 	<code class="handler-cmd">{HANDLER_INSTALL_CMD}</code>
-	<button class="copy-btn" on:click={copyHandlerCmd}>
+	<button class="copy-btn" onclick={copyHandlerCmd}>
 		{handlerCopied ? 'Copied!' : 'Copy'}
 	</button>
 </div>
@@ -130,7 +130,7 @@
 			id="handler-installed"
 			type="checkbox"
 			checked={!!$profile.handlerInstalled}
-			on:change={(e) => setHandlerInstalled(e.currentTarget.checked)}
+			onchange={(e) => setHandlerInstalled(e.currentTarget.checked)}
 		/>
 		{#if !$profile.handlerInstalled}
 			<span class="handler-hint">Check this after installing to enable the "Open in Explorer" button</span>
@@ -151,7 +151,7 @@
 			class="path-input"
 			placeholder="C:\Share or /mnt/nas"
 			value={$profile.sourceRoots?.[name] ?? ''}
-			on:change={(e) => setSourceRoot(name, e.currentTarget.value)}
+			onchange={(e) => setSourceRoot(name, e.currentTarget.value)}
 		/>
 	</div>
 </div>

--- a/web/src/lib/StatsPanel.svelte
+++ b/web/src/lib/StatsPanel.svelte
@@ -3,15 +3,15 @@
 	import { getStats } from '$lib/api';
 	import type { SourceStats, StatsResponse } from '$lib/api';
 
-	let breakdownMode: 'kind' | 'ext' = 'kind';
-	let showAllExt = false;
+	let breakdownMode: 'kind' | 'ext' = $state('kind');
+	let showAllExt = $state(false);
 
-	let stats: StatsResponse | null = null;
-	let initialLoading = true;
-	let error: string | null = null;
-	let selectedSource = '';
+	let stats = $state<StatsResponse | null>(null);
+	let initialLoading = $state(true);
+	let error: string | null = $state(null);
+	let selectedSource = $state('');
 
-	$: currentSource = stats?.sources.find((s) => s.name === selectedSource) ?? stats?.sources[0] ?? null;
+	let currentSource = $derived(stats?.sources.find((s) => s.name === selectedSource) ?? stats?.sources[0] ?? null);
 
 	let interval: ReturnType<typeof setInterval> | null = null;
 
@@ -217,12 +217,12 @@
 					<button
 						class="mode-btn"
 						class:active={breakdownMode === 'kind'}
-						on:click={() => { breakdownMode = 'kind'; showAllExt = false; }}
+						onclick={() => { breakdownMode = 'kind'; showAllExt = false; }}
 					>Kind</button>
 					<button
 						class="mode-btn"
 						class:active={breakdownMode === 'ext'}
-						on:click={() => { breakdownMode = 'ext'; showAllExt = false; }}
+						onclick={() => { breakdownMode = 'ext'; showAllExt = false; }}
 					>Extension</button>
 				</div>
 			</div>
@@ -260,7 +260,7 @@
 					{/each}
 				</div>
 				{#if exts.length > 20}
-					<button class="show-more" on:click={() => (showAllExt = !showAllExt)}>
+					<button class="show-more" onclick={() => (showAllExt = !showAllExt)}>
 						{showAllExt ? 'Show less' : `Show all ${exts.length} extensions`}
 					</button>
 				{/if}

--- a/web/src/lib/VideoViewer.svelte
+++ b/web/src/lib/VideoViewer.svelte
@@ -2,23 +2,28 @@
 	import { parseMetaTags } from '$lib/metaTags';
 	import MetaDrawer from '$lib/MetaDrawer.svelte';
 
-	export let src: string;
-	/** Extracted metadata lines (line_number === 1, starting with '['). */
-	export let metaLines: { content: string }[] = [];
+	let {
+		src,
+		metaLines = []
+	}: {
+		src: string;
+		/** Extracted metadata lines (line_number === 1, starting with '['). */
+		metaLines?: { content: string }[];
+	} = $props();
 
-	$: hasMeta = metaLines.length > 0;
+	let hasMeta = $derived(metaLines.length > 0);
 
-	let noVideoTrack = false;
-	let mediaError: string | null = null;
+	let noVideoTrack = $state(false);
+	let mediaError: string | null = $state(null);
 
 	// Extract container format from metadata (e.g. "[VIDEO:format] mkv" → "MKV").
-	$: videoFormat = (() => {
+	let videoFormat = $derived.by(() => {
 		for (const m of metaLines) {
 			const match = m.content.match(/\[VIDEO:format\]\s*(\S+)/i);
 			if (match) return match[1].toUpperCase();
 		}
 		return null;
-	})();
+	});
 
 	function onLoadedMetadata(e: Event) {
 		const video = e.target as HTMLVideoElement;
@@ -50,8 +55,8 @@
 		{#if mediaError}
 			<div class="codec-warning">{mediaError}</div>
 		{/if}
-		<!-- svelte-ignore a11y-media-has-caption -->
-		<video controls {src} class="video-player" on:loadedmetadata={onLoadedMetadata} on:error={onError}>
+		<!-- svelte-ignore a11y_media_has_caption -->
+		<video controls {src} class="video-player" onloadedmetadata={onLoadedMetadata} onerror={onError}>
 			Your browser does not support the video tag.
 		</video>
 	</div>


### PR DESCRIPTION
## Summary

Second step of the incremental Svelte runes migration (see #40 for the first). Converts `About`, `AdminPanel`, `AudioViewer`, `DirectoryTree`, `MarkdownViewer`, `MetaDrawer`, `Preferences`, `StatsPanel`, `VideoViewer` from legacy syntax to runes.

This group has no dispatch/callback-prop conversions — the patterns exercised are:

- `export let` → `$props()` destructuring (all files)
- Local mutable `let` → `$state()` — required in runes mode, since plain `let` is no longer implicitly reactive once a component adopts runes (`About`, `AdminPanel`, `Preferences`, `StatsPanel`, `DirectoryTree`)
- `$:` derived value → `$derived()`/`$derived.by()` (`VideoViewer`, `StatsPanel`)
- `$:` side-effect block → `$effect()` (`DirectoryTree`'s live-update listener, which calls an async refresh function — a real side effect, not a pure derivation)
- `<slot />` → `children: Snippet` + `{@render children?.()}` (`MetaDrawer`)
- `on:click`/`on:change` → `onclick`/`onchange` (all files with handlers)

**Bugs found and fixed along the way:**
- `StatsPanel`: `let stats: T | null = $state(null)` caused a real TypeScript narrowing bug — TS narrowed `stats` to `null` at the immediately-following `$derived` call, producing "property does not exist on type never" errors. Fixed via `$state<T | null>(null)` (type on the rune's generic, not the `let` binding).
- `AudioViewer`/`VideoViewer`: `<!-- svelte-ignore a11y-media-has-caption -->` used the old kebab-case rule name, which Svelte 5 no longer recognizes — silently letting the real a11y warning through unsuppressed. Renamed to `a11y_media_has_caption`.

All 22 icon components plus `SearchHelpContent` and `AppLogo` needed **zero changes** — they have no `<script>` block at all, nothing to migrate.

**No caller changes needed** anywhere in this group.

## Test plan

- [x] `pnpm run check` — 0 errors (1 benign informational warning on `MetaDrawer`'s intentional one-time prop→state snapshot, which doesn't fail the build)
- [x] `pnpm run build` — clean
- [x] `pnpm run test` — 199/199 passing
- [x] Live-tested in Playwright against a real running `find-server` instance: Preferences dropdowns + Reset buttons (confirms `$state`/store round-trip), Stats/Admin/About tabs loading real async data, About's "Check for updates" button flow — zero console errors throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)