### PR TITLE
chore: migrate Group 5 (high-traffic core UX) to Svelte 5 runes (5/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Changed
 
+- **Svelte runes migration (incremental, 5/N)** — `AdvancedSearch`, `TopBar`, `SearchView`, `FileView`, `SearchResult` converted from legacy syntax to runes, plus the `ResultList`/`+page.svelte` call sites touched to forward the new callback props. Highlights:
+  - `AdvancedSearch`'s `dispatch('change', ...)` became an `onChange` callback prop; `isDirty`/`sourceFiltered`/`filterCount` and friends became `$derived`.
+  - `TopBar` (the most complex file in this group): `isSearchActive` is a genuinely two-way `$bindable` written from an internal `$effect` (`isTyping || searching`); the `liveQuery` typeahead state is seeded from the one-way `query` prop with a resync `$effect` that deliberately keeps an explicit `_prevQuery` guard (documented inline) — the effect also reads `taOpen`, and without the guard it would clobber in-progress typing whenever `taOpen` toggles alone, even though `query` itself hasn't changed.
+  - `SearchResult` (formerly `SearchResultItem`) no longer dispatches `open` — it calls the new `onOpen` callback prop directly, so `ResultList`'s usage became `{onOpen}` instead of `on:open={(e) => onOpen?.(e.detail)}`.
+  - `SearchView`/`FileView`/`+page.svelte` handler signatures updated in lockstep (`handleSearch`, `handleFilterChange`, `openFile`, etc. now take plain objects instead of `CustomEvent`s) since both components share the same handlers in `+page.svelte`.
+  - `FileView`'s internal `<FileViewer>` usage is intentionally left on `on:lineselect`/`on:open`/`on:navigateDir`/`on:navigate` — `FileViewer.svelte` itself is Group 6 (not yet migrated).
+  - Verified live end-to-end: search, hit-nav (prev/next within a file card), alias-badge expand, opening a result into `FileView`, the back button, and the Advanced Search toggle.
+
+### Changed
+
 - **Svelte runes migration (incremental, 4/N)** — `CommandPalette`, `DirListing`, `PathBar`, `TreeRow`, `SearchBox`, `DirectImageViewer` converted from legacy syntax to runes, plus follow-up touches to `DirectoryTree`/`MultiSourceTree` (Group 2/3) to forward the new `onOpen` callback now that `TreeRow` no longer dispatches a `CustomEvent`. Highlights:
   - `TreeRow` (the most complex file so far): recursive `<svelte:self>` replaced with a self-import (also newly deprecated in Svelte 5); several genuine side-effect `$:` blocks (auto-scroll, auto-expand, live-refresh) converted to `$effect`.
   - `CommandPalette`'s `beforeUpdate` + manual `prevOpen` guard — a workaround for a Svelte 4 infinite-loop hazard when reactively reading a `bind:this` element inside a `tick().then()` callback — was removed. `$effect` only tracks reads made synchronously during its callback, so the same logic as a plain `$effect(() => { if (open) {...} })` no longer has that hazard. Verified by reopening the palette twice in the same session.

--- a/web/src/lib/AdvancedSearch.svelte
+++ b/web/src/lib/AdvancedSearch.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
 	import { clickOutside } from '$lib/clickOutside';
 	import IconBack from '$lib/icons/IconBack.svelte';
 	import IconFilter from '$lib/icons/IconFilter.svelte';
@@ -7,37 +6,48 @@
 	import type { SearchScope, SearchMatchType } from '$lib/searchPrefixes';
 	import MobilePanel from '$lib/MobilePanel.svelte';
 
-	/** All available source names. */
-	export let sources: string[] = [];
-	/** Currently active sources (empty = all). */
-	export let selectedSources: string[] = [];
-	/** Currently active kind filter (empty = all). */
-	export let selectedKinds: string[] = [];
-	/** Current date-from value as ISO string (YYYY-MM-DD), or empty. */
-	export let dateFrom = '';
-	/** Current date-to value as ISO string (YYYY-MM-DD), or empty. */
-	export let dateTo = '';
-	/** Whether case-sensitive matching is active. */
-	export let caseSensitive = false;
-	/** Current scope selection. */
-	export let scope: SearchScope = 'line';
-	/** Current match type selection. */
-	export let matchType: SearchMatchType = 'fuzzy';
+	type ChangeDetail = { sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType };
 
-	const dispatch = createEventDispatcher<{
-		change: { sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType };
-	}>();
+	let {
+		sources = [],
+		selectedSources = [],
+		selectedKinds = [],
+		dateFrom = '',
+		dateTo = '',
+		caseSensitive = false,
+		scope = 'line',
+		matchType = 'fuzzy',
+		onChange
+	}: {
+		/** All available source names. */
+		sources?: string[];
+		/** Currently active sources (empty = all). */
+		selectedSources?: string[];
+		/** Currently active kind filter (empty = all). */
+		selectedKinds?: string[];
+		/** Current date-from value as ISO string (YYYY-MM-DD), or empty. */
+		dateFrom?: string;
+		/** Current date-to value as ISO string (YYYY-MM-DD), or empty. */
+		dateTo?: string;
+		/** Whether case-sensitive matching is active. */
+		caseSensitive?: boolean;
+		/** Current scope selection. */
+		scope?: SearchScope;
+		/** Current match type selection. */
+		matchType?: SearchMatchType;
+		onChange?: (detail: ChangeDetail) => void;
+	} = $props();
 
-	let isOpen = false;
+	let isOpen = $state(false);
 
 	// Draft state — what the user is currently editing inside the panel.
-	let draftSources: string[] = [];
-	let draftKinds: string[] = [];
-	let draftFrom = '';
-	let draftTo = '';
-	let draftCaseSensitive = false;
-	let draftScope: SearchScope = 'line';
-	let draftMatchType: SearchMatchType = 'fuzzy';
+	let draftSources: string[] = $state([]);
+	let draftKinds: string[] = $state([]);
+	let draftFrom = $state('');
+	let draftTo = $state('');
+	let draftCaseSensitive = $state(false);
+	let draftScope: SearchScope = $state('line');
+	let draftMatchType: SearchMatchType = $state('fuzzy');
 
 	// Sync draft from props whenever the panel opens.
 	function openPanel() {
@@ -58,7 +68,7 @@
 	}
 
 	function apply() {
-		dispatch('change', {
+		onChange?.({
 			sources: draftSources,
 			kinds: draftKinds,
 			dateFrom: isoToUnix(draftFrom),
@@ -78,7 +88,7 @@
 		draftCaseSensitive = false;
 		draftScope = 'line';
 		draftMatchType = 'fuzzy';
-		dispatch('change', { sources: [], kinds: [], caseSensitive: false, scope: 'line', matchType: 'fuzzy' });
+		onChange?.({ sources: [], kinds: [], caseSensitive: false, scope: 'line', matchType: 'fuzzy' });
 		isOpen = false;
 	}
 
@@ -99,24 +109,25 @@
 	}
 
 	// Whether the draft differs from what's currently applied (props).
-	$: isDirty =
+	let isDirty = $derived(
 		JSON.stringify(draftSources.slice().sort()) !== JSON.stringify(selectedSources.slice().sort()) ||
 		JSON.stringify(draftKinds.slice().sort()) !== JSON.stringify(selectedKinds.slice().sort()) ||
 		draftFrom !== dateFrom ||
 		draftTo !== dateTo ||
 		draftCaseSensitive !== caseSensitive ||
 		draftScope !== scope ||
-		draftMatchType !== matchType;
+		draftMatchType !== matchType
+	);
 
-	$: sourceFiltered = selectedSources.length > 0 && selectedSources.length < sources.length;
-	$: kindFiltered = selectedKinds.length > 0;
-	$: dateFiltered = dateFrom !== '' || dateTo !== '';
-	$: scopeActive = scope !== 'line';
-	$: matchActive = matchType !== 'fuzzy';
-	$: anyFilter = sourceFiltered || kindFiltered || dateFiltered || caseSensitive || scopeActive || matchActive;
+	let sourceFiltered = $derived(selectedSources.length > 0 && selectedSources.length < sources.length);
+	let kindFiltered = $derived(selectedKinds.length > 0);
+	let dateFiltered = $derived(dateFrom !== '' || dateTo !== '');
+	let scopeActive = $derived(scope !== 'line');
+	let matchActive = $derived(matchType !== 'fuzzy');
+	let anyFilter = $derived(sourceFiltered || kindFiltered || dateFiltered || caseSensitive || scopeActive || matchActive);
 
 	// Count badge: number of active filter dimensions
-	$: filterCount = (sourceFiltered ? 1 : 0) + (kindFiltered ? 1 : 0) + (dateFiltered ? 1 : 0) + (caseSensitive ? 1 : 0) + (scopeActive ? 1 : 0) + (matchActive ? 1 : 0);
+	let filterCount = $derived((sourceFiltered ? 1 : 0) + (kindFiltered ? 1 : 0) + (dateFiltered ? 1 : 0) + (caseSensitive ? 1 : 0) + (scopeActive ? 1 : 0) + (matchActive ? 1 : 0));
 
 	function showFromPicker() {
 		(document.getElementById('adv-date-from') as HTMLInputElement)?.showPicker();
@@ -141,7 +152,7 @@
 	<button
 		class="trigger"
 		class:active={anyFilter}
-		on:click={() => (isOpen ? (isOpen = false) : openPanel())}
+		onclick={() => (isOpen ? (isOpen = false) : openPanel())}
 		title="Advanced filters"
 	>
 		<IconFilter />
@@ -155,7 +166,7 @@
 	{#if isOpen}
 		<div class="panel">
 			<div class="panel-mobile-header">
-				<button class="panel-back" on:click={() => (isOpen = false)} aria-label="Close filters">
+				<button class="panel-back" onclick={() => (isOpen = false)} aria-label="Close filters">
 					<IconBack />
 				</button>
 				<span class="panel-mobile-title">Filters</span>
@@ -166,7 +177,7 @@
 						<div class="section-header">
 							<span class="section-title">Sources</span>
 							{#if draftSources.length > 0 && draftSources.length < sources.length}
-								<button class="clear-link" on:click={() => (draftSources = [])}>All</button>
+								<button class="clear-link" onclick={() => (draftSources = [])}>All</button>
 							{/if}
 						</div>
 						<div class="source-list">
@@ -175,7 +186,7 @@
 									<input
 										type="checkbox"
 										checked={draftSources.includes(source)}
-										on:change={() => toggleDraftSource(source)}
+										onchange={() => toggleDraftSource(source)}
 									/>
 									<span class="source-name">{source}</span>
 								</label>
@@ -187,7 +198,7 @@
 				<div class="section">
 					<div class="section-header">
 						{#if draftKinds.length > 0}
-							<button class="clear-link" on:click={() => (draftKinds = [])}>All</button>
+							<button class="clear-link" onclick={() => (draftKinds = [])}>All</button>
 						{/if}
 					</div>
 					{#each KIND_GROUPS as group}
@@ -200,7 +211,7 @@
 								<input
 									type="checkbox"
 									checked={draftKinds.includes(opt.value)}
-									on:change={() => toggleDraftKind(opt.value)}
+									onchange={() => toggleDraftKind(opt.value)}
 								/>
 								<span class="kind-label">{opt.label}</span>
 							</label>
@@ -213,7 +224,7 @@
 					<div class="section-header">
 						<span class="section-title">Date range</span>
 						{#if draftFrom || draftTo}
-							<button class="clear-link" on:click={() => { draftFrom = ''; draftTo = ''; }}>Clear</button>
+							<button class="clear-link" onclick={() => { draftFrom = ''; draftTo = ''; }}>Clear</button>
 						{/if}
 					</div>
 					<div class="date-row">
@@ -226,7 +237,7 @@
 								type="date"
 								bind:value={draftFrom}
 							/>
-							<button class="cal-btn" tabindex="-1" on:click={showFromPicker}>📅</button>
+							<button class="cal-btn" tabindex="-1" onclick={showFromPicker}>📅</button>
 						</div>
 					</div>
 					<div class="date-row">
@@ -239,7 +250,7 @@
 								type="date"
 								bind:value={draftTo}
 							/>
-							<button class="cal-btn" tabindex="-1" on:click={showToPicker}>📅</button>
+							<button class="cal-btn" tabindex="-1" onclick={showToPicker}>📅</button>
 						</div>
 					</div>
 				</div>
@@ -253,7 +264,7 @@
 							<button
 								class="toggle-btn"
 								class:active={draftScope === opt.value}
-								on:click={() => (draftScope = opt.value)}
+								onclick={() => (draftScope = opt.value)}
 								type="button"
 							>{opt.label}</button>
 						{/each}
@@ -269,7 +280,7 @@
 							<button
 								class="toggle-btn"
 								class:active={draftMatchType === opt.value}
-								on:click={() => (draftMatchType = opt.value)}
+								onclick={() => (draftMatchType = opt.value)}
 								type="button"
 							>{opt.label}</button>
 						{/each}
@@ -286,9 +297,9 @@
 
 			<div class="footer">
 				{#if anyFilter}
-					<button class="clear-all" on:click={clearAll}>Clear all</button>
+					<button class="clear-all" onclick={clearAll}>Clear all</button>
 				{/if}
-				<button class="apply-btn" class:dirty={isDirty} disabled={!isDirty} on:click={apply}>Apply</button>
+				<button class="apply-btn" class:dirty={isDirty} disabled={!isDirty} onclick={apply}>Apply</button>
 			</div>
 		</div>
 	{/if}

--- a/web/src/lib/FileView.svelte
+++ b/web/src/lib/FileView.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
 	import { goto } from '$app/navigation';
 	import PathBar from '$lib/PathBar.svelte';
 	import FileViewer from '$lib/FileViewer.svelte';
@@ -9,33 +8,57 @@
 	import type { SearchScope, SearchMatchType } from '$lib/searchPrefixes';
 	import TopBar from '$lib/TopBar.svelte';
 
-	export let fileView: FileViewState;
-	export let showBack = true;
-	export let showTree: boolean;
-	export let query: string;
-	export let scope: SearchScope = 'line';
-	export let matchType: SearchMatchType = 'fuzzy';
-	export let searching: boolean;
-	export let sources: string[];
-	export let selectedSources: string[];
-	export let selectedKinds: string[] = [];
-	export let dateFrom = '';
-	export let dateTo = '';
-	export let caseSensitive = false;
+	type FilterChangeDetail = { sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType };
+	type OpenFileFromTreeDetail = { source: string; path: string; kind: string; archivePath?: string; showAsDirectory?: boolean };
+	type OpenDirFileDetail = { source: string; path: string; kind: string; archivePath?: string };
 
-	const dispatch = createEventDispatcher<{
-		back: void;
-		search: { query: string };
-		filterChange: { sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType };
-		treeToggle: void;
-		openFileFromTree: { source: string; path: string; kind: string; archivePath?: string; showAsDirectory?: boolean };
-		openDirFile: { source: string; path: string; kind: string; archivePath?: string };
-		openDir: { prefix: string };
-		lineselect: { selection: LineSelection };
-		navigateDir: { prefix: string };
-	}>();
+	let {
+		fileView,
+		showBack = true,
+		showTree,
+		query,
+		scope = 'line',
+		matchType = 'fuzzy',
+		searching,
+		sources,
+		selectedSources,
+		selectedKinds = [],
+		dateFrom = '',
+		dateTo = '',
+		caseSensitive = false,
+		onBack,
+		onSearch,
+		onFilterChange,
+		onTreeToggle,
+		onOpenFileFromTree,
+		onOpenDirFile,
+		onOpenDir,
+		onLineSelect
+	}: {
+		fileView: FileViewState;
+		showBack?: boolean;
+		showTree: boolean;
+		query: string;
+		scope?: SearchScope;
+		matchType?: SearchMatchType;
+		searching: boolean;
+		sources: string[];
+		selectedSources: string[];
+		selectedKinds?: string[];
+		dateFrom?: string;
+		dateTo?: string;
+		caseSensitive?: boolean;
+		onBack?: () => void;
+		onSearch?: (detail: { query: string }) => void;
+		onFilterChange?: (detail: FilterChangeDetail) => void;
+		onTreeToggle?: () => void;
+		onOpenFileFromTree?: (detail: OpenFileFromTreeDetail) => void;
+		onOpenDirFile?: (detail: OpenDirFileDetail) => void;
+		onOpenDir?: (detail: { prefix: string }) => void;
+		onLineSelect?: (detail: { selection: LineSelection }) => void;
+	} = $props();
 
-	$: pathBarPath = fileView.panelMode === 'dir' ? fileView.dirPrefix : fileView.file.outer;
+	let pathBarPath = $derived(fileView.panelMode === 'dir' ? fileView.dirPrefix : fileView.file.outer);
 </script>
 
 <TopBar
@@ -50,9 +73,9 @@
 	{caseSensitive}
 	{scope}
 	{matchType}
-	on:search={(e) => dispatch('search', e.detail)}
-	on:treeToggle={() => dispatch('treeToggle')}
-	on:filterChange={(e) => dispatch('filterChange', e.detail)}
+	{onSearch}
+	{onTreeToggle}
+	{onFilterChange}
 />
 
 <div class="viewer-wrap">
@@ -61,12 +84,12 @@
 		path={pathBarPath}
 		archivePath={fileView.panelMode === 'file' ? fileView.file.inner ?? null : null}
 		{showBack}
-		onBack={() => dispatch('back')}
+		onBack={() => onBack?.()}
 		onNavigate={(action) => {
 			if (action.type === 'dir') {
-				dispatch('openDir', { prefix: action.prefix });
+				onOpenDir?.({ prefix: action.prefix });
 			} else {
-				dispatch('openFileFromTree', { source: fileView.source, path: action.path, kind: action.kind });
+				onOpenFileFromTree?.({ source: fileView.source, path: action.path, kind: action.kind });
 			}
 		}}
 	/>
@@ -74,8 +97,8 @@
 		<DirListing
 			source={fileView.source}
 			prefix={fileView.dirPrefix}
-			onOpenFile={(detail) => dispatch('openDirFile', detail)}
-			onOpenDir={(detail) => dispatch('openDir', detail)}
+			onOpenFile={(detail) => onOpenDirFile?.(detail)}
+			onOpenDir={(detail) => onOpenDir?.(detail)}
 		/>
 	{:else}
 		{#key `${fileView.source}:${fileView.file.full}`}
@@ -85,10 +108,10 @@
 				archivePath={fileView.file.inner}
 				selection={fileView.selection}
 				preferOriginal={fileView.selection.length === 0}
-				on:lineselect={(e) => dispatch('lineselect', e.detail)}
-				on:open={(e) => dispatch('openDirFile', e.detail)}
-				on:navigateDir={(e) => dispatch('openDir', e.detail)}
-				on:navigate={(e) => dispatch('openFileFromTree', { source: fileView.source, path: e.detail.path, kind: 'unknown' })}
+				on:lineselect={(e) => onLineSelect?.(e.detail)}
+				on:open={(e) => onOpenDirFile?.(e.detail)}
+				on:navigateDir={(e) => onOpenDir?.(e.detail)}
+				on:navigate={(e) => onOpenFileFromTree?.({ source: fileView.source, path: e.detail.path, kind: 'unknown' })}
 			/>
 		{/key}
 	{/if}

--- a/web/src/lib/ResultList.svelte
+++ b/web/src/lib/ResultList.svelte
@@ -45,7 +45,7 @@
 		{#each groups as group (group.key)}
 			{@const isDeleted = deletedPaths.has(`${group.hits[0].source}:${group.hits[0].path}`)}
 			<div class="result-pad" class:deleted={isDeleted}>
-				<SearchResultItem hits={group.hits} {query} on:open={(e) => onOpen?.(e.detail)} />
+				<SearchResultItem hits={group.hits} {query} {onOpen} />
 			</div>
 		{/each}
 	{/if}

--- a/web/src/lib/SearchResult.svelte
+++ b/web/src/lib/SearchResult.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, onMount } from 'svelte';
+	import { onMount } from 'svelte';
 	import IconChevronLeft from '$lib/icons/IconChevronLeft.svelte';
 	import IconChevronRight from '$lib/icons/IconChevronRight.svelte';
 	import type { SearchResult, ContextLine } from '$lib/api';
@@ -7,20 +7,25 @@
 	import { highlightLine } from '$lib/highlight';
 	import { contextWindow } from '$lib/settingsStore';
 
-	/** All hits for this file, ordered by relevance (first hit is primary). */
-	export let hits: SearchResult[];
-	/** Current search query — used to highlight matches in the filename for path-only results. */
-	export let query = '';
+	let {
+		hits,
+		query = '',
+		onOpen
+	}: {
+		/** All hits for this file, ordered by relevance (first hit is primary). */
+		hits: SearchResult[];
+		/** Current search query — used to highlight matches in the filename for path-only results. */
+		query?: string;
+		onOpen?: (result: SearchResult) => void;
+	} = $props();
 
-	$: result = hits[activeHitIndex] ?? hits[0];
+	let activeHitIndex = $state(0);
+	let result = $derived(hits[activeHitIndex] ?? hits[0]);
 
-	const dispatch = createEventDispatcher<{ open: SearchResult }>();
-
-	let activeHitIndex = 0;
-	let contextStart = 0;
-	let contextMatchIndex: number | null = null;
-	let contextLines: ContextLine[] = [];
-	let contextLoaded = false;
+	let contextStart = $state(0);
+	let contextMatchIndex: number | null = $state(null);
+	let contextLines: ContextLine[] = $state([]);
+	let contextLoaded = $state(false);
 	let el: HTMLElement;
 
 	onMount(() => {
@@ -97,7 +102,7 @@
 	}
 
 	function openFile() {
-		dispatch('open', hits[activeHitIndex] ?? hits[0]);
+		onOpen?.(hits[activeHitIndex] ?? hits[0]);
 	}
 
 	function formatSize(bytes: number | null): string {
@@ -114,7 +119,7 @@
 
 	function openAlias(alias: string) {
 		const i = alias.indexOf('::');
-		dispatch('open', {
+		onOpen?.({
 			...result,
 			path: i >= 0 ? alias.slice(0, i) : alias,
 			archive_path: i >= 0 ? alias.slice(i + 2) : null,
@@ -185,20 +190,20 @@
 		return out;
 	}
 
-	let aliasesExpanded = false;
+	let aliasesExpanded = $state(false);
 
 	/** Highlighted HTML for context lines (set after loadContext resolves). */
-	let highlightedContextLines: string[] = [];
+	let highlightedContextLines: string[] = $state([]);
 	/** Highlighted HTML for the snippet fallback (set after loadContext resolves). */
-	let highlightedSnippet = '';
+	let highlightedSnippet = $state('');
 </script>
 
 <article class="result" bind:this={el}>
-	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
 		class="result-header"
-		on:click={openFile}
-		on:keydown={handleKeydown}
+		onclick={openFile}
+		onkeydown={handleKeydown}
 		role="button"
 		tabindex="0"
 		title={isContentMatch(result) ? `Open file at line ${displayLine(result.line_number)}` : 'Open file'}
@@ -224,14 +229,14 @@
 			{#if hits.length === 1 && isContentMatch(hits[0])}
 				<span class="line-ref">:{displayLine(hits[0].line_number)}</span>
 			{:else if hits.length > 1}
-				<!-- svelte-ignore a11y-no-static-element-interactions -->
-				<!-- svelte-ignore a11y-click-events-have-key-events -->
-				<span class="hit-nav" title="{activeHitIndex + 1} of {hits.length}{hits[0].hits_truncated ? '+' : ''} hits" on:click|stopPropagation>
-					<button class="hit-nav-btn" class:hit-nav-hidden={activeHitIndex === 0} on:click|stopPropagation={() => switchToHit(activeHitIndex - 1)} title="Previous hit (line {displayLine(hits[activeHitIndex - 1]?.line_number ?? 0)})">
+				<!-- svelte-ignore a11y_no_static_element_interactions -->
+				<!-- svelte-ignore a11y_click_events_have_key_events -->
+				<span class="hit-nav" title="{activeHitIndex + 1} of {hits.length}{hits[0].hits_truncated ? '+' : ''} hits" onclick={(e) => e.stopPropagation()}>
+					<button class="hit-nav-btn" class:hit-nav-hidden={activeHitIndex === 0} onclick={(e) => { e.stopPropagation(); switchToHit(activeHitIndex - 1); }} title="Previous hit (line {displayLine(hits[activeHitIndex - 1]?.line_number ?? 0)})">
 						<IconChevronLeft />
 					</button>
 					<span class="line-ref nav-line-ref">:{displayLine(hits[activeHitIndex].line_number)}</span>
-					<button class="hit-nav-btn" class:hit-nav-hidden={activeHitIndex >= hits.length - 1} on:click|stopPropagation={() => switchToHit(activeHitIndex + 1)} title="Next hit (line {displayLine(hits[activeHitIndex + 1]?.line_number ?? 0)})">
+					<button class="hit-nav-btn" class:hit-nav-hidden={activeHitIndex >= hits.length - 1} onclick={(e) => { e.stopPropagation(); switchToHit(activeHitIndex + 1); }} title="Next hit (line {displayLine(hits[activeHitIndex + 1]?.line_number ?? 0)})">
 						<IconChevronRight />
 					</button>
 					{#if hits[0].hits_truncated}
@@ -242,11 +247,12 @@
 		</div>
 		<div class="result-row2">
 			{#if result.duplicate_paths && result.duplicate_paths.length > 0}
-				<!-- svelte-ignore a11y-click-events-have-key-events -->
+				<!-- svelte-ignore a11y_no_static_element_interactions -->
+				<!-- svelte-ignore a11y_click_events_have_key_events -->
 				<span
 					class="alias-badge"
 					title={aliasesExpanded ? 'Hide duplicate paths' : 'Show duplicate paths'}
-					on:click|stopPropagation={() => (aliasesExpanded = !aliasesExpanded)}
+					onclick={(e) => { e.stopPropagation(); aliasesExpanded = !aliasesExpanded; }}
 				>+{result.duplicate_paths.length} duplicate{result.duplicate_paths.length === 1 ? '' : 's'}</span>
 			{/if}
 			<div class="file-meta">
@@ -263,7 +269,7 @@
 	{#if aliasesExpanded && result.duplicate_paths && result.duplicate_paths.length > 0}
 		<div class="aliases">
 			{#each result.duplicate_paths as alias}
-				<button class="alias-path" on:click|stopPropagation={() => openAlias(alias)}>{alias}</button>
+				<button class="alias-path" onclick={(e) => { e.stopPropagation(); openAlias(alias); }}>{alias}</button>
 			{/each}
 		</div>
 	{/if}

--- a/web/src/lib/SearchView.svelte
+++ b/web/src/lib/SearchView.svelte
@@ -1,52 +1,83 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
 	import ResultList from '$lib/ResultList.svelte';
 	import type { SearchResult } from '$lib/api';
 	import { parseSearchPrefixes } from '$lib/searchPrefixes';
 	import type { SearchScope, SearchMatchType } from '$lib/searchPrefixes';
 	import TopBar from '$lib/TopBar.svelte';
 
-	export let query: string;
-	export let scope: SearchScope = 'line';
-	export let matchType: SearchMatchType = 'fuzzy';
-	export let searching: boolean;
-	export let sources: string[];
-	export let selectedSources: string[];
-	export let selectedKinds: string[] = [];
-	export let dateFrom = '';
-	export let dateTo = '';
-	export let caseSensitive = false;
-	export let results: SearchResult[] = [];
-	export let totalResults = 0;
-	export let resultsCapped = false;
-	export let searchError: string | null = null;
-	export let searchId = 0;
-	export let showTree = false;
-	export let filterDateFrom: number | undefined = undefined;
-	export let filterDateTo: number | undefined = undefined;
-	export let nlpDateLabel: string | undefined = undefined;
-	export let nlpDetectedPhrase: string | undefined = undefined;
-	export let nlpConflict = false;
-	export let resultsStale = false;
-	export let deletedPaths: Set<string> = new Set();
+	type FilterChangeDetail = { sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType };
 
-	const dispatch = createEventDispatcher<{
-		search: { query: string };
-		filterChange: { sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType };
-		clearNlpDate: void;
-		open: SearchResult;
-		treeToggle: void;
-		refreshResults: void;
-		dismissStale: void;
-	}>();
+	let {
+		query,
+		scope = 'line',
+		matchType = 'fuzzy',
+		searching,
+		sources,
+		selectedSources,
+		selectedKinds = [],
+		dateFrom = '',
+		dateTo = '',
+		caseSensitive = false,
+		results = [],
+		totalResults = 0,
+		resultsCapped = false,
+		searchError = null,
+		searchId = 0,
+		showTree = false,
+		filterDateFrom = undefined,
+		filterDateTo = undefined,
+		nlpDateLabel = undefined,
+		nlpDetectedPhrase = undefined,
+		nlpConflict = false,
+		resultsStale = false,
+		deletedPaths = new Set(),
+		onSearch,
+		onFilterChange,
+		onClearNlpDate,
+		onOpen,
+		onTreeToggle,
+		onRefreshResults,
+		onDismissStale
+	}: {
+		query: string;
+		scope?: SearchScope;
+		matchType?: SearchMatchType;
+		searching: boolean;
+		sources: string[];
+		selectedSources: string[];
+		selectedKinds?: string[];
+		dateFrom?: string;
+		dateTo?: string;
+		caseSensitive?: boolean;
+		results?: SearchResult[];
+		totalResults?: number;
+		resultsCapped?: boolean;
+		searchError?: string | null;
+		searchId?: number;
+		showTree?: boolean;
+		filterDateFrom?: number | undefined;
+		filterDateTo?: number | undefined;
+		nlpDateLabel?: string | undefined;
+		nlpDetectedPhrase?: string | undefined;
+		nlpConflict?: boolean;
+		resultsStale?: boolean;
+		deletedPaths?: Set<string>;
+		onSearch?: (detail: { query: string }) => void;
+		onFilterChange?: (detail: FilterChangeDetail) => void;
+		onClearNlpDate?: () => void;
+		onOpen?: (result: SearchResult) => void;
+		onTreeToggle?: () => void;
+		onRefreshResults?: () => void;
+		onDismissStale?: () => void;
+	} = $props();
 
 	let topBar: TopBar;
-	let isSearchActive = false;
+	let isSearchActive = $state(false);
 	export function focus() { topBar?.focus(); }
 
 	// Compute prefix chips from the current query.
-	$: prefixResult = parseSearchPrefixes(query);
-	$: prefixTokens = prefixResult.prefixTokens;
+	let prefixResult = $derived(parseSearchPrefixes(query));
+	let prefixTokens = $derived(prefixResult.prefixTokens);
 
 	function removePrefixToken(token: { raw: string; value: string }) {
 		// Replace the full prefix token with its bare value (the non-prefix part),
@@ -55,17 +86,17 @@
 		const newQuery = parts
 			.flatMap((t) => (t === token.raw ? (token.value ? [token.value] : []) : [t]))
 			.join(' ');
-		dispatch('search', { query: newQuery });
+		onSearch?.({ query: newQuery });
 	}
 
 	const SHORT_DATE = new Intl.DateTimeFormat('en-US', { month: 'numeric', day: 'numeric', year: 'numeric' });
 	function fmtTs(ts: number): string { return SHORT_DATE.format(new Date(ts * 1000)); }
-	$: resultDateSuffix = (() => {
+	let resultDateSuffix = $derived.by(() => {
 		if (filterDateFrom != null && filterDateTo != null) return ` between ${fmtTs(filterDateFrom)} and ${fmtTs(filterDateTo)}`;
 		if (filterDateFrom != null) return ` after ${fmtTs(filterDateFrom)}`;
 		if (filterDateTo != null) return ` before ${fmtTs(filterDateTo)}`;
 		return '';
-	})();
+	});
 </script>
 
 <TopBar
@@ -83,9 +114,9 @@
 	{scope}
 	{matchType}
 	{nlpDetectedPhrase}
-	on:search={(e) => dispatch('search', e.detail)}
-	on:treeToggle={() => dispatch('treeToggle')}
-	on:filterChange={(e) => dispatch('filterChange', e.detail)}
+	{onSearch}
+	{onTreeToggle}
+	{onFilterChange}
 />
 
 {#if prefixTokens.length > 0 || nlpDateLabel}
@@ -98,7 +129,7 @@
 					token.kind ? `type: ${token.kind}` : null,
 					token.dirSource ? `source: ${token.dirSource}${token.dirPrefix ? '/' + token.dirPrefix : ''}` : null,
 				].filter(Boolean).join(' · ')}</span>
-				<button class="nlp-dismiss" on:click={() => removePrefixToken(token)} aria-label="Remove prefix">✕</button>
+				<button class="nlp-dismiss" onclick={() => removePrefixToken(token)} aria-label="Remove prefix">✕</button>
 			</div>
 		{/each}
 		{#if nlpDateLabel}
@@ -111,7 +142,7 @@
 						aria-label="Date conflict: manual range overrides query date"
 					>!</span>
 				{:else}
-					<button class="nlp-dismiss" on:click={() => dispatch('clearNlpDate')} aria-label="Clear detected date">✕</button>
+					<button class="nlp-dismiss" onclick={() => onClearNlpDate?.()} aria-label="Clear detected date">✕</button>
 				{/if}
 			</div>
 		{/if}
@@ -130,8 +161,8 @@
 		{#if resultsStale}
 			<div class="stale-banner">
 				Index updated —
-				<button class="stale-refresh" on:click={() => dispatch('refreshResults')}>refresh results</button>
-				<button class="stale-dismiss" on:click={() => dispatch('dismissStale')} aria-label="Dismiss">✕</button>
+				<button class="stale-refresh" onclick={() => onRefreshResults?.()}>refresh results</button>
+				<button class="stale-dismiss" onclick={() => onDismissStale?.()} aria-label="Dismiss">✕</button>
 			</div>
 		{/if}
 		{#key searchId}
@@ -140,7 +171,7 @@
 				searching={isSearchActive}
 				{deletedPaths}
 				{query}
-				onOpen={(result) => dispatch('open', result)}
+				{onOpen}
 			/>
 		{/key}
 	{/if}

--- a/web/src/lib/TopBar.svelte
+++ b/web/src/lib/TopBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import SearchBox from '$lib/SearchBox.svelte';
 	import AdvancedSearch from '$lib/AdvancedSearch.svelte';
@@ -11,56 +11,79 @@
 	import { listDir } from '$lib/api';
 	import type { SearchScope, SearchMatchType } from '$lib/searchPrefixes';
 
-	export let query: string;
-	export let searching: boolean;
-	export let showTree: boolean;
-	export let sources: string[] = [];
-	export let selectedSources: string[] = [];
-	export let selectedKinds: string[] = [];
-	export let dateFrom = '';
-	export let dateTo = '';
-	export let caseSensitive = false;
-	export let scope: SearchScope = 'line';
-	export let matchType: SearchMatchType = 'fuzzy';
-	export let nlpDetectedPhrase: string | undefined = undefined;
+	type FilterChangeDetail = { sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType };
 
-	const dispatch = createEventDispatcher<{
-		search: { query: string };
-		treeToggle: void;
-		filterChange: { sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType };
-	}>();
+	let {
+		query,
+		searching,
+		showTree,
+		sources = [],
+		selectedSources = [],
+		selectedKinds = [],
+		dateFrom = '',
+		dateTo = '',
+		caseSensitive = false,
+		scope = 'line',
+		matchType = 'fuzzy',
+		nlpDetectedPhrase = undefined,
+		isSearchActive = $bindable(false),
+		onSearch,
+		onTreeToggle,
+		onFilterChange
+	}: {
+		query: string;
+		searching: boolean;
+		showTree: boolean;
+		sources?: string[];
+		selectedSources?: string[];
+		selectedKinds?: string[];
+		dateFrom?: string;
+		dateTo?: string;
+		caseSensitive?: boolean;
+		scope?: SearchScope;
+		matchType?: SearchMatchType;
+		nlpDetectedPhrase?: string | undefined;
+		isSearchActive?: boolean;
+		onSearch?: (detail: { query: string }) => void;
+		onTreeToggle?: () => void;
+		onFilterChange?: (detail: FilterChangeDetail) => void;
+	} = $props();
 
-	export let isSearchActive = false;
+	let helpOpen = $state(false);
+	let isTyping = $state(false);
 
-	let helpOpen = false;
-	let isTyping = false;
-	$: isSearchActive = isTyping || searching;
-	$: nlpHighlightSpan = (() => {
+	// isSearchActive is a $bindable output, computed entirely from isTyping/
+	// searching — the parent only ever reads it, never sets it independently.
+	$effect(() => {
+		isSearchActive = isTyping || searching;
+	});
+
+	let nlpHighlightSpan = $derived.by(() => {
 		if (!nlpDetectedPhrase || isTyping) return undefined;
 		const idx = query.toLowerCase().indexOf(nlpDetectedPhrase.toLowerCase());
 		if (idx === -1) return undefined;
 		return [idx, idx + nlpDetectedPhrase.length] as [number, number];
-	})();
+	});
 
 	let searchBox: SearchBox;
 	export function focus() { searchBox?.focus(); }
 
 	// ── Dir typeahead ──────────────────────────────────────────────────────────
 
-	let liveQuery = query;
-	let searchFocused = false;
-	let taOpen = false;
-	let taItems: string[] = [];
-	let taActiveIdx = -1;
-	let taLoading = false;
-	let taSourcePhase = false;
+	let liveQuery = $state(query);
+	let searchFocused = $state(false);
+	let taOpen = $state(false);
+	let taItems: string[] = $state([]);
+	let taActiveIdx = $state(-1);
+	let taLoading = $state(false);
+	let taSourcePhase = $state(false);
 	/**
 	 * The resolved token currently displayed in the typeahead (may differ from
 	 * liveQuery when auto-advance jumped ahead). Used by selectItem so it always
 	 * builds the next token from the correct resolved position.
 	 * Reset to null whenever the user types (liveQuery changes from rawInput).
 	 */
-	let activeToken: string | null = null;
+	let activeToken: string | null = $state(null);
 
 	// Simple in-memory cache: "source:prefix" → dir names
 	const dirCache = new Map<string, string[]>();
@@ -160,7 +183,7 @@
 				: `source:${src}/`;
 			activeToken = finalToken;
 			liveQuery = replaceLastDirToken(liveQuery, finalToken);
-			dispatch('search', { query: liveQuery });
+			onSearch?.({ query: liveQuery });
 
 			taSourcePhase = false;
 			taLoading = false;
@@ -182,7 +205,7 @@
 				const finalToken = `source:${source}/${resolved.path}/`;
 				activeToken = finalToken;
 				liveQuery = replaceLastDirToken(liveQuery, finalToken);
-				dispatch('search', { query: liveQuery });
+				onSearch?.({ query: liveQuery });
 			} else {
 				activeToken = token;
 			}
@@ -220,27 +243,33 @@
 		}
 		activeToken = null; // reset so reactive block re-runs updateTypeahead for next level
 		liveQuery = replaceLastDirToken(liveQuery, newToken);
-		dispatch('search', { query: liveQuery });
+		onSearch?.({ query: liveQuery });
 		taActiveIdx = -1;
 	}
 
 	// React to live query changes. Guard: skip when liveQuery was updated by
 	// auto-advance (activeToken set) to avoid re-triggering updateTypeahead.
-	$: {
+	$effect(() => {
 		const token = getDirToken(liveQuery);
 		if (token && searchFocused && token !== activeToken) {
 			updateTypeahead(token);
 		} else if (!token) {
 			closeTypeahead();
 		}
-	}
+	});
 
 	// Sync liveQuery when the query PROP changes externally (e.g. chip removed).
+	// The explicit _prevQuery comparison (rather than relying on $effect's own
+	// dependency tracking) matters here: this effect also reads taOpen, and
+	// without the guard it would re-fire (and clobber in-progress typing) simply
+	// because taOpen toggled, even when query itself hasn't changed.
 	let _prevQuery = query;
-	$: if (query !== _prevQuery) {
-		_prevQuery = query;
-		if (!taOpen) liveQuery = query;
-	}
+	$effect(() => {
+		if (query !== _prevQuery) {
+			_prevQuery = query;
+			if (!taOpen) liveQuery = query;
+		}
+	});
 
 	function handleTypeaheadKeydown(e: KeyboardEvent) {
 		if (!taOpen || !searchFocused) return;
@@ -269,14 +298,14 @@
 </script>
 
 <div class="topbar">
-	<button class="logo-btn" on:click={() => (helpOpen = true)} aria-label="Search help">
+	<button class="logo-btn" onclick={() => (helpOpen = true)} aria-label="Search help">
 		<AppLogo />
 	</button>
 	<button
 		class="tree-toggle"
 		class:active={showTree}
 		data-tooltip="Toggle file tree"
-		on:click={() => dispatch('treeToggle')}
+		onclick={() => onTreeToggle?.()}
 	>◫</button>
 	<div class="help-wrap-outer"><SearchHelp bind:open={helpOpen} /></div>
 	<div class="search-wrap">
@@ -286,7 +315,7 @@
 			searching={isSearchActive}
 			{nlpHighlightSpan}
 			bind:isTyping
-			onChange={(detail) => dispatch('search', { query: detail.query })}
+			onChange={(detail) => onSearch?.({ query: detail.query })}
 			onRawInput={(detail) => {
 				const wasDeletion = detail.query.length < liveQuery.length;
 				liveQuery = detail.query;
@@ -324,11 +353,11 @@
 				{caseSensitive}
 				{scope}
 				{matchType}
-				on:change={(e) => dispatch('filterChange', e.detail)}
+				onChange={(detail) => onFilterChange?.(detail)}
 			/>
 		</div>
 	{/if}
-	<button class="gear-btn" on:click={() => goto('/settings')}>⚙</button>
+	<button class="gear-btn" onclick={() => goto('/settings')}>⚙</button>
 </div>
 
 <MobilePanel bind:open={helpOpen} title="Search Help">

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -430,9 +430,9 @@
 
 	// ── Search event handlers ────────────────────────────────────────────────────
 
-	function handleSearch(e: CustomEvent<{ query: string }>) {
+	function handleSearch(detail: { query: string }) {
 		// New query text = fresh NLP parse (clear any prior suppression).
-		query = e.detail.query;
+		query = detail.query;
 		doSearch(query, selectedSources);
 	}
 
@@ -447,14 +447,14 @@
 		doSearch(stripped, selectedSources);
 	}
 
-	function handleFilterChange(e: CustomEvent<{ sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType }>) {
-		selectedSources = e.detail.sources;
-		selectedKinds = e.detail.kinds;
-		caseSensitive = e.detail.caseSensitive;
-		scope = e.detail.scope;
-		matchType = e.detail.matchType;
-		dateFromTs = e.detail.dateFrom;
-		dateToTs = e.detail.dateTo;
+	function handleFilterChange(detail: { sources: string[]; kinds: string[]; dateFrom?: number; dateTo?: number; caseSensitive: boolean; scope: SearchScope; matchType: SearchMatchType }) {
+		selectedSources = detail.sources;
+		selectedKinds = detail.kinds;
+		caseSensitive = detail.caseSensitive;
+		scope = detail.scope;
+		matchType = detail.matchType;
+		dateFromTs = detail.dateFrom;
+		dateToTs = detail.dateTo;
 		// Keep ISO strings in sync so AdvancedSearch inputs remain controlled.
 		dateFromStr = dateFromTs != null ? new Date(dateFromTs * 1000).toISOString().slice(0, 10) : '';
 		dateToStr = dateToTs != null ? new Date(dateToTs * 1000).toISOString().slice(0, 10) : '';
@@ -470,8 +470,7 @@
 		pushState();
 	}
 
-	function openFile(e: CustomEvent<SearchResult>) {
-		const r = e.detail;
+	function openFile(r: SearchResult) {
 		const file = FilePath.fromParts(r.path, r.archive_path ?? null);
 		// Server line_number: 0=path, 1=metadata, 2+=content (LINE_CONTENT_START=2).
 		// Display line number = server line_number - 1 (1-based content index).
@@ -489,26 +488,26 @@
 		openFileView({ source: r.source, file, selection, panelMode: 'file', dirPrefix: '' });
 	}
 
-	function handleOpenFileFromTree(e: CustomEvent<{ source: string; path: string; kind: string; archivePath?: string; showAsDirectory?: boolean }>) {
-		const file = FilePath.fromParts(e.detail.path, e.detail.archivePath ?? null);
-		if (e.detail.showAsDirectory) {
-			openFileView({ source: e.detail.source, file, selection: [], panelMode: 'dir', dirPrefix: file.full + '::' });
+	function handleOpenFileFromTree(detail: { source: string; path: string; kind: string; archivePath?: string; showAsDirectory?: boolean }) {
+		const file = FilePath.fromParts(detail.path, detail.archivePath ?? null);
+		if (detail.showAsDirectory) {
+			openFileView({ source: detail.source, file, selection: [], panelMode: 'dir', dirPrefix: file.full + '::' });
 		} else {
-			openFileView({ source: e.detail.source, file, selection: [], panelMode: 'file', dirPrefix: '' });
+			openFileView({ source: detail.source, file, selection: [], panelMode: 'file', dirPrefix: '' });
 		}
 	}
 
-	function handleOpenDirFile(e: CustomEvent<{ source: string; path: string; kind: string; archivePath?: string }>) {
-		const file = FilePath.fromParts(e.detail.path, e.detail.archivePath ?? null);
+	function handleOpenDirFile(detail: { source: string; path: string; kind: string; archivePath?: string }) {
+		const file = FilePath.fromParts(detail.path, detail.archivePath ?? null);
 		openFileView({ ...(fileView!), file, selection: [], panelMode: 'file' });
 	}
 
-	function handleOpenDir(e: CustomEvent<{ prefix: string }>) {
-		openFileView({ ...(fileView!), panelMode: 'dir', dirPrefix: e.detail.prefix });
+	function handleOpenDir(detail: { prefix: string }) {
+		openFileView({ ...(fileView!), panelMode: 'dir', dirPrefix: detail.prefix });
 	}
 
-	function handleLineSelect(e: CustomEvent<{ selection: LineSelection }>) {
-		if (fileView) fileView = { ...fileView, selection: e.detail.selection };
+	function handleLineSelect(detail: { selection: LineSelection }) {
+		if (fileView) fileView = { ...fileView, selection: detail.selection };
 		syncHash();
 	}
 
@@ -594,7 +593,7 @@
 				sources={sourceNames}
 				activeSource={fileView?.source ?? null}
 				activePath={fileView?.file.full ?? null}
-				onOpen={(detail) => handleOpenFileFromTree(new CustomEvent('open', { detail }))}
+				onOpen={handleOpenFileFromTree}
 			/>
 		</aside>
 		<button
@@ -622,14 +621,14 @@
 				{caseSensitive}
 				dateFrom={dateFromStr}
 				dateTo={dateToStr}
-				on:back={handleBack}
-				on:search={handleSearch}
-				on:filterChange={handleFilterChange}
-				on:treeToggle={handleTreeToggle}
-				on:openFileFromTree={handleOpenFileFromTree}
-				on:openDirFile={handleOpenDirFile}
-				on:openDir={handleOpenDir}
-				on:lineselect={handleLineSelect}
+				onBack={handleBack}
+				onSearch={handleSearch}
+				onFilterChange={handleFilterChange}
+				onTreeToggle={handleTreeToggle}
+				onOpenFileFromTree={handleOpenFileFromTree}
+				onOpenDirFile={handleOpenDirFile}
+				onOpenDir={handleOpenDir}
+				onLineSelect={handleLineSelect}
 			/>
 		{:else}
 			<SearchView
@@ -655,15 +654,15 @@
 				nlpDateLabel={nlpResult?.dateLabel}
 				nlpDetectedPhrase={nlpResult?.detectedPhrase}
 				nlpConflict={!!nlpResult?.dateLabel && (dateFromTs != null || dateToTs != null)}
-				on:search={handleSearch}
-				on:filterChange={handleFilterChange}
-				on:clearNlpDate={handleClearNlpDate}
-				on:open={openFile}
-				on:treeToggle={handleTreeToggle}
+				onSearch={handleSearch}
+				onFilterChange={handleFilterChange}
+				onClearNlpDate={handleClearNlpDate}
+				onOpen={openFile}
+				onTreeToggle={handleTreeToggle}
 				{resultsStale}
 				{deletedPaths}
-				on:refreshResults={() => { doSearch(query, selectedSources); }}
-				on:dismissStale={() => { resultsStale = false; }}
+				onRefreshResults={() => { doSearch(query, selectedSources); }}
+				onDismissStale={() => { resultsStale = false; }}
 			/>
 			<div bind:this={sentinel}></div>
 			{#if loadingMore}


### PR DESCRIPTION
## Summary
- Converts `AdvancedSearch`, `TopBar`, `SearchView`, `FileView`, `SearchResult` from legacy Svelte syntax to runes (`$props()`, `$state`, `$derived`, callback props replacing `createEventDispatcher`).
- Updates the `ResultList` and `+page.svelte` call sites to forward the new callback props (`onOpen`, `onSearch`, `onFilterChange`, etc.) now that these components no longer dispatch `CustomEvent`s.
- `TopBar`'s `isSearchActive` is genuinely two-way (`$bindable`, written from an internal `$effect`); its typeahead `liveQuery` resync effect deliberately keeps an explicit `_prevQuery` guard (documented inline) since the effect also reads `taOpen` and would otherwise clobber in-progress typing.
- `FileView`'s internal `<FileViewer>` usage is intentionally left on `on:lineselect`/`on:open`/`on:navigateDir`/`on:navigate` — `FileViewer.svelte` itself is Group 6 (not yet migrated).
- Part of the incremental, file-by-file Svelte 5 runes migration (5 of 6 planned groups).

## Test plan
- [x] `pnpm run check` — 0 errors
- [x] `pnpm run build` — succeeds
- [x] `pnpm run test` — 199 tests passed
- [x] Live-tested against a real `find-server` + dev server with Playwright: search, hit-nav (prev/next within a file card), alias-badge expand, opening a result into `FileView`, back button, Advanced Search toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)