### PR TITLE
fix: release script pushes to master, but the default branch is main

### DIFF
--- a/.mise/tasks/release
+++ b/.mise/tasks/release
@@ -120,13 +120,13 @@ read -rp "Push and create GitHub release? [Y/n] " PUSH
 PUSH="${PUSH:-Y}"
 if [[ ! "$PUSH" =~ ^[Yy]$ ]]; then
   echo ""
-  echo "  git push origin master v$NEW_VERSION"
+  echo "  git push origin main v$NEW_VERSION"
   echo "  gh release create v$NEW_VERSION --title \"v$NEW_VERSION\" --notes \"...\""
   exit 0
 fi
 
 echo "→ Pushing commits and tag..."
-git push origin master "v$NEW_VERSION"
+git push origin main "v$NEW_VERSION"
 
 # Extract release notes for this version from CHANGELOG
 NOTES=$(python3 - "$NEW_VERSION" <<'PYEOF'


### PR DESCRIPTION
## Summary
- \`git push origin master\` in \`.mise/tasks/release\` would fail — this repo's default branch was renamed to \`main\` a while back and this script was never updated.

## Test plan
- N/A (one-line branch name fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)