### PR TITLE
Release 0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+---
+
+## [0.7.7] - 2026-07-08
+
 ### Fixed
 
 - **`cross`-based ARM/Windows builds: sccache wasn't actually being used** — `Cross.toml`'s `volumes` key was under the top-level `[build]` section, but `cross` only reads `volumes`/`passthrough` from `[build.env]`, so the sccache binary and cache dir mounts were silently dropped (cross even warned "found unused key(s)"). Even moved to the right place, `cross` doesn't support Docker's `host:container` remap — it always mounts a volume at the same absolute path inside the container as on the host — so `RUSTC_WRAPPER=sccache` (a bare name) could never resolve via a `PATH` lookup the container doesn't have. Fixed by resolving `RUSTC_WRAPPER` to sccache's absolute path via `which sccache` in `.mise.toml`'s `build-arm`/`build-win` task env blocks (no hardcoded paths — portable across machines), and mounting/passing it through by that same env var name in `Cross.toml`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "find-client"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "find-common"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "find-content-store"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "find-common",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-archive"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dicom"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "dicom-dictionary-std",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dispatch"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "find-extract-dicom",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-epub"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-html"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-media"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-office"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "calamine",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pdf"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pe"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-text"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "content_inspector",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-types"
-version = "0.6.1"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "find-handler"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "url",
 ]
@@ -1833,7 +1833,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "find-preview-dicom"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "dicom-object",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "find-server"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-client"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [[bin]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-common"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [dependencies]

--- a/crates/content-store/Cargo.toml
+++ b/crates/content-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-content-store"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extract-types/Cargo.toml
+++ b/crates/extract-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-types"
-version = "0.6.1"
+version = "0.7.7"
 edition = "2021"
 
 [dependencies]

--- a/crates/extractors/archive/Cargo.toml
+++ b/crates/extractors/archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-archive"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dicom/Cargo.toml
+++ b/crates/extractors/dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dicom"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dispatch/Cargo.toml
+++ b/crates/extractors/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dispatch"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/epub/Cargo.toml
+++ b/crates/extractors/epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-epub"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/html/Cargo.toml
+++ b/crates/extractors/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-html"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/media/Cargo.toml
+++ b/crates/extractors/media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-media"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/office/Cargo.toml
+++ b/crates/extractors/office/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-office"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pdf/Cargo.toml
+++ b/crates/extractors/pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pdf"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pe/Cargo.toml
+++ b/crates/extractors/pe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pe"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/text/Cargo.toml
+++ b/crates/extractors/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-text"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [lib]

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-handler"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [[bin]]

--- a/crates/preview-dicom/Cargo.toml
+++ b/crates/preview-dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-preview-dicom"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [[bin]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-server"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary

Version bump 0.7.6 → 0.7.7 and CHANGELOG cutover for the [Unreleased] entries already on main:

- File viewer: targeted redraws for paged scrolling, plus a pagination bug the fix surfaced
- `cross`-based ARM/Windows builds: sccache wasn't actually being used
- Silenced 5 recurring `state_referenced_locally` build warnings
- Several Rust dependency bumps (rand, zip, quick-xml, scraper, calamine, nom-exif, kamadak-exif, gray_matter)
- Svelte runes migration (final group)

Also fixes `crates/extract-types/Cargo.toml`, which had drifted to `0.6.1` (not tracking the rest of the workspace at `0.7.6`) — the release script's naive per-crate `sed` substitution would have silently skipped it again. Bumped to `0.7.7` to match everyone else.

## Test plan
- [x] `cargo check --workspace` — clean
- [x] All 17 workspace crate versions now consistently `0.7.7`

Once merged, I'll tag `v0.7.7` on the resulting commit and publish the GitHub release (repo branch protection requires the version-bump commit to land via PR — `main` doesn't allow direct pushes even from the release script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)