### PR TITLE
perf: batch phase1 SQLite commits instead of one per file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Changed
+
+- **Phase 1 indexing: batch SQLite commits instead of one per file** — investigation into disk write amplification on a production deployment found that `sources/{source}.db` (up to 19GB there) was seeing 100-250x write amplification during upload bursts: `worker/pipeline.rs`'s `process_file_phase1_fallback` opened and committed its own transaction per file, so each commit rewrote WAL frames and interior btree pages of the whole multi-GB database, for every single file. Changed the per-file transaction to a SQLite savepoint (rusqlite behaves identically to a transaction when no outer one is open, and nests cleanly when one is), and `worker/request.rs`'s phase1 loop now opens one transaction per `PHASE1_BATCH_SIZE` (25) files instead of relying on each file's own commit — one bad file still only rolls back its own savepoint, not the rest of the batch already accumulated. Also folded the outer-archive stale-inner-member delete (previously its own separate mini-transaction per file) into the same per-file savepoint. Added a regression test (`batch_crossing_phase1_batch_size_indexes_every_file`) covering a request with more files than `PHASE1_BATCH_SIZE`, verifying every file — before, at, and after the internal commit boundary — is still correctly persisted.
+  - This addresses bulk `find-scan` uploads (many files per request) directly. It does *not* address a burst of many separate single-file requests (e.g. a file watcher uploading one changed file at a time) — each such request still gets its own DB connection and its own transaction, since batching only happens *within* one request's file list. Tracked as a follow-up: [#59](https://github.com/outsharked/find-anything/issues/59).
+
 ---
 
 ## [0.7.7] - 2026-07-08

--- a/crates/server/src/worker/pipeline.rs
+++ b/crates/server/src/worker/pipeline.rs
@@ -48,14 +48,17 @@ pub(super) fn process_file_phase1_fallback(
         .unwrap_or_default()
         .as_secs() as i64;
 
-    // If re-indexing an outer archive, delete stale inner members first (SQL only).
-    // Orphaned chunks left in ZIPs are reclaimed by the periodic compaction pass.
-    if !skip_inner_delete && is_outer_archive(&file.path, &file.kind) && file.mtime == 0 {
-        let like_pat = composite_like_prefix(&file.path);
-        let tx = conn.unchecked_transaction()?;
-        tx.execute("DELETE FROM files WHERE path LIKE ?1", rusqlite::params![like_pat])?;
-        tx.commit()?;
-    }
+    // If re-indexing an outer archive, stale inner members need deleting (SQL
+    // only). Computed here but issued as the first statement inside the
+    // savepoint below, alongside the upsert — the SELECT for existing_record
+    // just below matches this file's own path exactly, never a "path LIKE"
+    // inner-member row, so doing the delete after the read here doesn't
+    // change what that query sees. Orphaned chunks left in ZIPs are reclaimed
+    // by the periodic compaction pass.
+    let inner_delete_pattern = (!skip_inner_delete
+        && is_outer_archive(&file.path, &file.kind)
+        && file.mtime == 0)
+        .then(|| composite_like_prefix(&file.path));
 
     // Single query for the existing record: id, mtime, size, kind, file_hash, line_count.
     let existing_record: Option<(i64, i64, i64, String, Option<String>, i64)> = conn.query_row(
@@ -111,14 +114,26 @@ pub(super) fn process_file_phase1_fallback(
             Vec::new()
         };
 
-    // Single transaction for the whole file.
+    // Single savepoint for the whole file. A savepoint (rather than
+    // conn.transaction()) lets callers batch many files into one enclosing
+    // SQLite transaction — see request.rs's phase1 loop, which commits every
+    // PHASE1_BATCH_SIZE files instead of after each one, collapsing the
+    // WAL/page-rewrite cost of many small commits — while still rolling back
+    // just this file's writes (RAII: dropped without commit() = rollback) if
+    // something fails partway through. When no enclosing transaction is open
+    // (e.g. tests calling this directly), a savepoint behaves exactly like a
+    // transaction: releasing the outermost savepoint commits to disk.
     let t_fts = std::time::Instant::now();
-    let tx = conn.transaction()?;
+    let sp = conn.savepoint()?;
+
+    if let Some(like_pat) = &inner_delete_pattern {
+        sp.execute("DELETE FROM files WHERE path LIKE ?1", rusqlite::params![like_pat])?;
+    }
 
     let line_count = file.lines.len() as i64;
 
     // Upsert the file record, keeping the same file_id on re-index.
-    let file_id: i64 = tx.query_row(
+    let file_id: i64 = sp.query_row(
         "INSERT INTO files (path, mtime, size, kind, scanner_version, indexed_at, extract_ms, file_hash, line_count)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
          ON CONFLICT(path) DO UPDATE SET
@@ -157,7 +172,7 @@ pub(super) fn process_file_phase1_fallback(
         }
         if (pos as i64) < MAX_LINES_PER_FILE {
             let old_rowid = encode_fts_rowid(file_id, pos as i64);
-            tx.execute(
+            sp.execute(
                 "INSERT INTO lines_fts(lines_fts, rowid, content) VALUES('delete', ?1, ?2)",
                 rusqlite::params![old_rowid, content],
             )?;
@@ -177,7 +192,7 @@ pub(super) fn process_file_phase1_fallback(
             continue;
         }
         let rowid = encode_fts_rowid(file_id, line_number);
-        tx.execute(
+        sp.execute(
             "INSERT INTO lines_fts(rowid, content) VALUES (?1, ?2)",
             rusqlite::params![rowid, line.content.trim_end()],
         )?;
@@ -185,10 +200,10 @@ pub(super) fn process_file_phase1_fallback(
 
     // Update duplicate tracking.
     if let Some(hash) = &file.file_hash {
-        upsert_duplicate_tracking(&tx, hash, file_id)?;
+        upsert_duplicate_tracking(&sp, hash, file_id)?;
     }
 
-    tx.commit()?;
+    sp.commit()?;
     super::warn_slow(t_fts, 10, "fts_insert_phase1", &file.path);
 
     if existing_id.is_none() {
@@ -201,13 +216,13 @@ pub(super) fn process_file_phase1_fallback(
 
 /// Insert duplicate tracking entries when 2+ files share a file_hash.
 fn upsert_duplicate_tracking(
-    tx: &rusqlite::Transaction,
+    conn: &Connection,
     hash: &str,
     file_id: i64,
 ) -> Result<()> {
     // Find other files with the same file_hash.
     let other_ids: Vec<i64> = {
-        let mut stmt = tx.prepare(
+        let mut stmt = conn.prepare(
             "SELECT id FROM files WHERE file_hash = ?1 AND id != ?2",
         )?;
         let ids: Vec<i64> = stmt.query_map(rusqlite::params![hash, file_id], |r| r.get(0))?
@@ -217,12 +232,12 @@ fn upsert_duplicate_tracking(
     if !other_ids.is_empty() {
         // Insert for all existing duplicates and for the current file.
         for other_id in &other_ids {
-            tx.execute(
+            conn.execute(
                 "INSERT OR IGNORE INTO duplicates(file_hash, file_id) VALUES(?1, ?2)",
                 rusqlite::params![hash, other_id],
             )?;
         }
-        tx.execute(
+        conn.execute(
             "INSERT OR IGNORE INTO duplicates(file_hash, file_id) VALUES(?1, ?2)",
             rusqlite::params![hash, file_id],
         )?;

--- a/crates/server/src/worker/request.rs
+++ b/crates/server/src/worker/request.rs
@@ -26,6 +26,13 @@ use crate::normalize;
 use super::{StatusHandle, WorkerConfig, timed, warn_slow};
 use super::pipeline;
 
+/// How many files' phase1 savepoints to accumulate into one SQLite
+/// transaction before committing. Each commit rewrites WAL frames and
+/// interior btree pages of the source DB; on a multi-GB DB, committing after
+/// every single file (as opposed to a batch of them) is the dominant cost
+/// when many small files are indexed one at a time.
+const PHASE1_BATCH_SIZE: usize = 25;
+
 // ── Context structs ─────────────────────────────────────────────────────────────
 
 /// Per-request path context for `process_request_async`.
@@ -327,6 +334,19 @@ fn process_request_phase1(
 
     tracing::debug!("{tag} → index {} files", n_files);
     let index_loop_start = std::time::Instant::now();
+    // Batch phase1's per-file savepoints into one SQLite transaction every
+    // PHASE1_BATCH_SIZE files instead of committing after each one — each
+    // commit rewrites WAL frames and interior btree pages of the source DB,
+    // which on a multi-GB DB dominates write volume when many small files are
+    // indexed individually (see CHANGELOG). process_file_phase1 still uses a
+    // per-file savepoint internally, so one bad file only rolls back its own
+    // savepoint, not the rest of the batch already accumulated in this
+    // transaction.
+    let batched = !files_owned.is_empty();
+    if batched {
+        conn.execute_batch("BEGIN")?;
+    }
+    let mut since_commit = 0usize;
     for file in files_owned {
         if let Ok(mut guard) = status.lock() {
             *guard = find_common::api::WorkerStatus::Processing {
@@ -397,6 +417,16 @@ fn process_request_phase1(
         }
         warn_slow(file_start, 30, "process_file_phase1", &file.path);
         normalized_files.push(file); // moved, not cloned
+
+        since_commit += 1;
+        if since_commit >= PHASE1_BATCH_SIZE {
+            conn.execute_batch("COMMIT")?;
+            conn.execute_batch("BEGIN")?;
+            since_commit = 0;
+        }
+    }
+    if batched {
+        conn.execute_batch("COMMIT")?;
     }
     tracing::debug!("{tag} ← index {} files ({:.1}ms)", n_files, index_loop_start.elapsed().as_secs_f64() * 1000.0);
 
@@ -638,6 +668,59 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM files WHERE path = 'docs/readme.txt'", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 1, "expected file record in DB");
+    }
+
+    /// Regression test for the phase1 batched-commit change: a request with
+    /// more files than PHASE1_BATCH_SIZE must cross at least one internal
+    /// COMMIT/BEGIN boundary, and every file — before, at, and after that
+    /// boundary — must still end up correctly persisted.
+    #[test]
+    fn batch_crossing_phase1_batch_size_indexes_every_file() {
+        let (_tmp, data_dir, to_archive_dir, inbox_dir) = setup_dirs();
+        let (recent_tx, _rx) = tokio::sync::broadcast::channel::<RecentFile>(16);
+
+        let n_files = PHASE1_BATCH_SIZE + 5; // crosses exactly one batch boundary
+        let files: Vec<IndexFile> = (0..n_files)
+            .map(|i| make_index_file(&format!("batch/file{i:03}.txt"), FileKind::Text))
+            .collect();
+
+        let req = BulkRequest {
+            source: "batchsource".to_string(),
+            files,
+            delete_paths: vec![],
+            rename_paths: vec![],
+            scan_timestamp: Some(1_000_000),
+            indexing_failures: vec![],
+        };
+
+        let request_path = inbox_dir.join("req_batch.gz");
+        write_bulk_request_gz(&request_path, &req);
+
+        call_phase1(
+            &data_dir,
+            &request_path,
+            &to_archive_dir,
+            &make_status(),
+            make_worker_config(),
+            &recent_tx,
+            &make_stats_watch(),
+        )
+        .unwrap();
+
+        let db_path = data_dir.join("sources").join("batchsource.db");
+        let conn = crate::db::open(&db_path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM files WHERE path LIKE 'batch/%'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, n_files as i64, "every file across the batch boundary should be persisted");
+
+        // Spot-check the last file in the batch (the one committed by the
+        // *final* COMMIT after the loop, not one of the periodic ones).
+        let last_path = format!("batch/file{:03}.txt", n_files - 1);
+        let last_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM files WHERE path = ?1", [&last_path], |r| r.get(0))
+            .unwrap();
+        assert_eq!(last_count, 1, "last file in the batch should be persisted");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Investigation into disk write amplification on a production deployment found ~100-250x write amplification during upload bursts: each commit in `worker/pipeline.rs`'s `process_file_phase1_fallback` rewrote WAL frames and interior btree pages of the whole source DB (up to 19GB in that deployment), once per file.
- Changed the per-file transaction to a SQLite savepoint. rusqlite behaves identically to a transaction when no outer one is open, and nests cleanly when one is, so this needed no signature or call-site changes.
- `worker/request.rs`'s phase1 loop now opens one transaction per `PHASE1_BATCH_SIZE` (25) files instead of relying on each file's own commit. A bad file still only rolls back its own savepoint, not the rest of the batch already accumulated (RAII: a savepoint dropped without `commit()` rolls back).
- Folded the outer-archive stale-inner-member delete (previously its own separate mini-transaction per file) into the same per-file savepoint.
- Addresses bulk `find-scan` uploads directly. Does **not** address a burst of many separate single-file requests (e.g. a file watcher uploading one file at a time) — tracked as a follow-up in #59, since that needs coalescing across requests, a bigger change to the worker's dispatch model with real crash-recovery and lock-contention tradeoffs to work through first.

## Test plan
- [x] New regression test `batch_crossing_phase1_batch_size_indexes_every_file` — a request with more files than `PHASE1_BATCH_SIZE`, verifying every file (before, at, and after the internal commit boundary) is correctly persisted
- [x] `cargo test -p find-server` — 29 lib tests + 63 integration tests, all passing
- [x] `mise run clippy` — clean workspace-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)