### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+---
+
+## [0.8.0] - 2026-07-09
+
 ### Added
 
 - **Ctrl+G "go to line" dialog, and deep-link `#L…` hash edits now work** — editing the URL hash directly (e.g. typing `#L5000` in the address bar) previously did nothing: there was no `hashchange` listener at all, and `FileViewer` only computed its paged-mode anchor from the line selection once, at mount. Added a `hashchange` listener in `+page.svelte` and a `FileViewer` effect that reacts to the selection changing after mount — scrolling to the target line if it's already loaded (`isLineLoaded()`, new `lineSelection.ts` helper), or reloading centered on it (reusing the same `nextForwardOffset` anchor math as the initial load) if not. New `GoToLineDialog.svelte` (mirrors `CommandPalette`'s modal pattern) wires the same mechanism to Ctrl+G, gated to file view only since Ctrl+G is normally browser "find next". Verified live via Playwright against real paged files: cold-load-to-hash, runtime hash edits, and deep multi-page-skip jumps (temporarily shrinking `file_view_page_size` to force an 8-page skip) all resolve to a single correctly-anchored fetch, no incremental walk-through.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "find-client"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "find-common"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "find-content-store"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "find-common",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-archive"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dicom"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dicom-dictionary-std",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dispatch"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "find-extract-dicom",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-epub"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-html"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-media"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-office"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "calamine",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pdf"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pe"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-text"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "content_inspector",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-types"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "find-handler"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "url",
 ]
@@ -1833,7 +1833,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "find-preview-dicom"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dicom-object",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "find-server"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-client"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [[bin]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-common"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/content-store/Cargo.toml
+++ b/crates/content-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-content-store"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extract-types/Cargo.toml
+++ b/crates/extract-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-types"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/extractors/archive/Cargo.toml
+++ b/crates/extractors/archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-archive"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dicom/Cargo.toml
+++ b/crates/extractors/dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dicom"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dispatch/Cargo.toml
+++ b/crates/extractors/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dispatch"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/epub/Cargo.toml
+++ b/crates/extractors/epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-epub"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/html/Cargo.toml
+++ b/crates/extractors/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-html"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/media/Cargo.toml
+++ b/crates/extractors/media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-media"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/office/Cargo.toml
+++ b/crates/extractors/office/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-office"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pdf/Cargo.toml
+++ b/crates/extractors/pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pdf"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pe/Cargo.toml
+++ b/crates/extractors/pe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pe"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/text/Cargo.toml
+++ b/crates/extractors/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-text"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-handler"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [[bin]]

--- a/crates/preview-dicom/Cargo.toml
+++ b/crates/preview-dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-preview-dicom"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [[bin]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-server"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Version bump + CHANGELOG for v0.8.0. Tag `v0.8.0` has already been pushed and the [release workflow](https://github.com/outsharked/find-anything/actions/workflows/release.yml) triggered from it — this PR brings `main` in sync with the tagged commit (direct push was blocked by branch protection).

## Summary
- Bump all workspace crate versions 0.7.7 → 0.8.0
- Move `[Unreleased]` CHANGELOG entries into a new `[0.8.0] - 2026-07-09` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)