### PR TITLE
fix: include find-extract-dicom and find-extract-pe in release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,8 @@ jobs:
             "find-extract-office"
             "find-extract-epub"
             "find-extract-dispatch"
+            "find-extract-dicom"
+            "find-extract-pe"
           )
 
           mkdir -p "dist/${ARTIFACT}"


### PR DESCRIPTION
## Summary
- The release packaging step (`.github/workflows/release.yml`) builds the whole workspace but only copies a fixed list of binaries into the release tarball; `find-extract-dicom` and `find-extract-pe` were both missing from that list.
- PE extraction still worked despite the omission, since `find-extract-dispatch` (which *is* packaged) links `find-extract-pe` in directly as a library.
- DICOM did not: `find-scan` looks for a standalone `find-extract-dicom` subprocess for its extensionless magic-byte detection path, so every `.dcm` file was silently skipped with `extractor binary not found: find-extract-dicom`.

Found while building find-anything-demo's new `examples` source — its `dicom/` category indexed zero of its 5 real DICOM test files against a v0.8.0 release build.

## Test plan
- [x] `cargo build --release --workspace` already produces both binaries (confirmed both crates have a `[[bin]]` target and are already workspace members)
- [ ] Next tagged release should have `find-extract-dicom`/`find-extract-pe` present in the tarball — worth a quick manual check on the first release after this merges
- [ ] Re-run `find-anything-demo`'s `dicom/` category against that release to confirm all 5 `.dcm` files index and preview correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)