### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [0.8.1] - 2026-07-10
+
+### Fixed
+
+- **Release packaging: `find-extract-dicom` and `find-extract-pe` were missing from release tarballs** — `.github/workflows/release.yml`'s packaging step built the whole workspace but only copied a fixed `BINARIES` list into the tarball, and that list never included these two crates despite both having a `[[bin]]` target and being workspace members since their crates were added. PE extraction still worked because `find-extract-dispatch` (which *is* packaged) links `find-extract-pe` in directly as a library, but DICOM did not: `find-scan` looks for a standalone `find-extract-dicom` subprocess for its extensionless magic-byte detection path, so every release since DICOM support was added silently skipped all `.dcm` files with `extractor binary not found: find-extract-dicom`. Found while building find-anything-demo's `examples` source, whose `dicom/` category indexed zero of its 5 real DICOM test files against a v0.8.0 release build. ([#70](https://github.com/outsharked/find-anything/pull/70))
+
+---
+
 ## [0.8.0] - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "find-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "find-common"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "find-content-store"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "find-common",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-archive"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dicom"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "dicom-dictionary-std",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-dispatch"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "find-extract-dicom",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-epub"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-html"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-media"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-office"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "calamine",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pdf"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-pe"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "find-extract-types",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-text"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "content_inspector",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "find-extract-types"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "find-handler"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "url",
 ]
@@ -1833,7 +1833,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "find-preview-dicom"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "dicom-object",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "find-server"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-client"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [[bin]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-common"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/content-store/Cargo.toml
+++ b/crates/content-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-content-store"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extract-types/Cargo.toml
+++ b/crates/extract-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-types"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/extractors/archive/Cargo.toml
+++ b/crates/extractors/archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-archive"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dicom/Cargo.toml
+++ b/crates/extractors/dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dicom"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/dispatch/Cargo.toml
+++ b/crates/extractors/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-dispatch"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/epub/Cargo.toml
+++ b/crates/extractors/epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-epub"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/html/Cargo.toml
+++ b/crates/extractors/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-html"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/media/Cargo.toml
+++ b/crates/extractors/media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-media"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/office/Cargo.toml
+++ b/crates/extractors/office/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-office"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pdf/Cargo.toml
+++ b/crates/extractors/pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pdf"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/pe/Cargo.toml
+++ b/crates/extractors/pe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-pe"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/extractors/text/Cargo.toml
+++ b/crates/extractors/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-extract-text"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [lib]

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-handler"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [[bin]]

--- a/crates/preview-dicom/Cargo.toml
+++ b/crates/preview-dicom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-preview-dicom"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [[bin]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find-server"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Version bump + CHANGELOG for v0.8.1. Tag `v0.8.1` has already been pushed and the [release workflow](https://github.com/outsharked/find-anything/actions/workflows/release.yml) triggered from it — this PR brings `main` in sync with the tagged commit (direct push is blocked by branch protection).

## Summary
- Bump all workspace crate versions 0.8.0 → 0.8.1
- Move the `find-extract-dicom`/`find-extract-pe` release-packaging fix ([#70](https://github.com/outsharked/find-anything/pull/70)) from `[Unreleased]` into a new `[0.8.1] - 2026-07-10` CHANGELOG section

🤖 Generated with [Claude Code](https://claude.com/claude-code)