### PR TITLE
fix: image viewer Fit to viewport ignored small images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Image viewer "Fit to viewport" did nothing for images smaller than the panel** — the fit-scale calculation capped at 1 (native size) whenever the image already fit within the container, instead of scaling up to fill it. Now: opening an image defaults to native size unless it overflows the panel (in which case it auto-shrinks to fit), and the toolbar button is a real toggle between native size and fill-viewport (upscaling small images on request), with the icon highlighting to show which state is active.
+
 ---
 
 ## [0.8.1] - 2026-07-10

--- a/web/src/lib/DirectImageViewer.svelte
+++ b/web/src/lib/DirectImageViewer.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import IconFitViewport from '$lib/icons/IconFitViewport.svelte';
 	import IconAdjust from '$lib/icons/IconAdjust.svelte';
+	import { computeFitScale as computeFitScalePure, shouldDefaultToFit as shouldDefaultToFitPure } from '$lib/directImageViewerLogic';
 
 	let { src, svgMode = false }: { src: string; svgMode?: boolean } = $props();
 
@@ -12,6 +13,11 @@
 	let offsetX = $state(0);
 	let offsetY = $state(0);
 	let fitScale = $state(1);
+	// Whether the toolbar "fit to viewport" toggle is in its "fitted" state
+	// (image scaled to fill the panel) vs. its "native size" state (scale 1).
+	// Manual zoom/pan actions clear this so the icon doesn't lie about the
+	// current scale.
+	let isFitted = $state(true);
 
 	let loaded = $state(false);
 	let loadError = $state(false);
@@ -105,39 +111,50 @@
 		applyTransform();
 	}
 
+	// Recomputed on demand (image load, container resize, explicit "fit" click)
+	// rather than cached once — a container resize after load would otherwise
+	// leave fitScale stale, making "Fit to viewport" reapply an outdated value.
+	function computeFitScale(): number {
+		if (!container || !img) return 1;
+		return computeFitScalePure(container.clientWidth, container.clientHeight, img.naturalWidth, img.naturalHeight);
+	}
+
+	// Default view on load / reset: fit (shrink) only if the image actually
+	// overflows the panel; otherwise native size, so small images (e.g. a RAW
+	// file's embedded thumbnail) aren't upscaled unless the user asks for it
+	// via the fit toggle.
+	function applyDefaultView() {
+		if (svgMode) {
+			isFitted = true;
+			scale = 1;
+			fitScale = 1;
+		} else if (container && img) {
+			fitScale = computeFitScale();
+			isFitted = shouldDefaultToFitPure(
+				container.clientWidth,
+				container.clientHeight,
+				img.naturalWidth,
+				img.naturalHeight
+			);
+			scale = isFitted ? fitScale : 1;
+		}
+		offsetX = 0;
+		offsetY = 0;
+		applyTransform();
+	}
+
 	function onImageLoad() {
 		clearSpinnerTimer();
 		showSpinner = false;
 		loaded = true;
 		loadError = false;
 		rotation = 0;
-		if (svgMode) {
-			scale = 1;
-			fitScale = 1;
-			offsetX = 0;
-			offsetY = 0;
-			applyTransform();
-			return;
-		}
-		if (!container || !img) return;
-		const vw = container.clientWidth;
-		const vh = container.clientHeight;
-		const nw = img.naturalWidth;
-		const nh = img.naturalHeight;
-
-		if (nw <= vw && nh <= vh) {
-			fitScale = 1;
-		} else {
-			fitScale = Math.min(vw / nw, vh / nh);
-		}
-		scale = fitScale;
-		offsetX = 0;
-		offsetY = 0;
-		applyTransform();
+		applyDefaultView();
 	}
 
 	function onWheel(e: WheelEvent) {
 		e.preventDefault();
+		isFitted = false;
 		const delta = e.deltaY > 0 ? 0.9 : 1.1;
 		scale = clamp(scale * delta, minScale, MAX_SCALE);
 		applyTransform();
@@ -167,10 +184,7 @@
 
 	function onDblClick(e: MouseEvent) {
 		if ((e.target as Element).closest('.toolbar, .adjust-panel')) return;
-		scale = fitScale;
-		offsetX = 0;
-		offsetY = 0;
-		applyTransform();
+		applyDefaultView();
 	}
 
 	// Re-apply transform when flip changes. applyTransform() also reads scale/
@@ -186,31 +200,58 @@
 	let minScale = $derived(Math.min(0.01, fitScale * 0.5));
 
 	function zoomIn() {
+		isFitted = false;
 		scale = clamp(scale * 1.25, minScale, MAX_SCALE);
 		applyTransform();
 	}
 
 	function zoomOut() {
+		isFitted = false;
 		scale = clamp(scale / 1.25, minScale, MAX_SCALE);
 		applyTransform();
 	}
 
-	function reset() {
-		scale = fitScale;
+	// Toolbar toggle: fit-to-viewport <-> native size.
+	function toggleFit() {
+		isFitted = !isFitted;
+		if (isFitted) {
+			if (!svgMode) fitScale = computeFitScale();
+			scale = fitScale;
+		} else {
+			scale = 1;
+		}
 		offsetX = 0;
 		offsetY = 0;
 		applyTransform();
 	}
+
+	let resizeObserver: ResizeObserver | undefined;
 
 	onMount(() => {
 		if (!container || !img) return;
 		container.addEventListener('wheel', onWheel, { passive: false });
 		if (img.complete && img.naturalWidth > 0) onImageLoad();
 		else if (img.complete && img.naturalWidth === 0) onError();
+
+		// Keep fitScale current across panel/window resizes. If the toggle is
+		// still in its "fitted" state, re-fit the image too so it keeps filling
+		// the viewport as it resizes.
+		resizeObserver = new ResizeObserver(() => {
+			if (!loaded || loadError || svgMode) return;
+			fitScale = computeFitScale();
+			if (isFitted) {
+				scale = fitScale;
+				offsetX = 0;
+				offsetY = 0;
+				applyTransform();
+			}
+		});
+		resizeObserver.observe(container);
 	});
 
 	onDestroy(() => {
 		if (container) container.removeEventListener('wheel', onWheel);
+		resizeObserver?.disconnect();
 		clearSpinnerTimer();
 	});
 </script>
@@ -245,7 +286,11 @@
 		<div class="toolbar">
 			<button onclick={(e) => { e.stopPropagation(); zoomIn(); }} title="Zoom in">+</button>
 			<button onclick={(e) => { e.stopPropagation(); zoomOut(); }} title="Zoom out">−</button>
-			<button onclick={(e) => { e.stopPropagation(); reset(); }} title="Fit to viewport">
+			<button
+				onclick={(e) => { e.stopPropagation(); toggleFit(); }}
+				title={isFitted ? 'Native size' : 'Fit to viewport'}
+				class:active={isFitted}
+			>
 				<IconFitViewport />
 			</button>
 			<button onclick={(e) => { e.stopPropagation(); rotateLeft(); }} title="Rotate left">↺</button>

--- a/web/src/lib/directImageViewerLogic.test.ts
+++ b/web/src/lib/directImageViewerLogic.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { computeFitScale, shouldDefaultToFit } from './directImageViewerLogic';
+
+describe('computeFitScale', () => {
+	it('downscales an image larger than the container in both dimensions', () => {
+		// 4000x3000 image in an 800x600 viewport — should shrink by 0.2x.
+		expect(computeFitScale(800, 600, 4000, 3000)).toBeCloseTo(0.2);
+	});
+
+	it('downscales using the more constraining dimension', () => {
+		// Wide image, narrow container: width is the binding constraint.
+		expect(computeFitScale(400, 1000, 2000, 1000)).toBeCloseTo(0.2);
+	});
+
+	it('upscales an image smaller than the container to fill it', () => {
+		// A 93 MB Nikon D850 .NEF preview is often a small embedded JPEG
+		// thumbnail (e.g. 300x225) — much smaller than a typical viewer panel.
+		// "Fit to viewport" should fill the available space in both directions,
+		// not leave the image at native size just because it's already small.
+		expect(computeFitScale(1200, 800, 300, 225)).toBeCloseTo(800 / 225);
+	});
+
+	it('upscales using the more constraining dimension', () => {
+		// Tall narrow image in a wide container: height is the binding constraint.
+		expect(computeFitScale(1000, 400, 100, 200)).toBeCloseTo(2);
+	});
+
+	it('returns 1 for a zero-sized natural image (not yet loaded)', () => {
+		expect(computeFitScale(800, 600, 0, 0)).toBe(1);
+	});
+
+	it('returns 1 for a zero-sized container (not yet measured/hidden)', () => {
+		expect(computeFitScale(0, 0, 800, 600)).toBe(1);
+	});
+
+	it('returns 1 when the image exactly matches the container size', () => {
+		expect(computeFitScale(800, 600, 800, 600)).toBe(1);
+	});
+});
+
+describe('shouldDefaultToFit', () => {
+	it('defaults to fit when the image overflows both dimensions', () => {
+		expect(shouldDefaultToFit(800, 600, 4000, 3000)).toBe(true);
+	});
+
+	it('defaults to fit when the image overflows only one dimension', () => {
+		expect(shouldDefaultToFit(800, 600, 4000, 300)).toBe(true);
+		expect(shouldDefaultToFit(800, 600, 300, 3000)).toBe(true);
+	});
+
+	it('defaults to native size when the image is smaller than the container in both dimensions', () => {
+		// The small D850 .NEF thumbnail case: don't upscale by default.
+		expect(shouldDefaultToFit(1200, 800, 300, 225)).toBe(false);
+	});
+
+	it('defaults to native size when the image exactly matches the container', () => {
+		expect(shouldDefaultToFit(800, 600, 800, 600)).toBe(false);
+	});
+
+	it('defaults to native size for a zero-sized natural image (not yet loaded)', () => {
+		expect(shouldDefaultToFit(800, 600, 0, 0)).toBe(false);
+	});
+
+	it('defaults to native size for a zero-sized container (not yet measured/hidden)', () => {
+		expect(shouldDefaultToFit(0, 0, 800, 600)).toBe(false);
+	});
+});

--- a/web/src/lib/directImageViewerLogic.ts
+++ b/web/src/lib/directImageViewerLogic.ts
@@ -1,0 +1,32 @@
+/**
+ * Computes the scale factor DirectImageViewer's "Fit to viewport" action applies:
+ * scale-to-contain, filling as much of the container as possible on the binding
+ * axis while preserving aspect ratio. Upscales small images as well as
+ * downscaling large ones — "fit" always fills the viewport.
+ */
+export function computeFitScale(
+	containerWidth: number,
+	containerHeight: number,
+	naturalWidth: number,
+	naturalHeight: number
+): number {
+	if (!naturalWidth || !naturalHeight || !containerWidth || !containerHeight) return 1;
+	return Math.min(containerWidth / naturalWidth, containerHeight / naturalHeight);
+}
+
+/**
+ * Decides the default view when an image first opens (or view is reset):
+ * fit-to-viewport (shrunk) only if the image actually overflows the
+ * container in some dimension; otherwise native size (scale 1), so small
+ * images aren't upscaled unless the user explicitly asks for it via the
+ * fit toggle.
+ */
+export function shouldDefaultToFit(
+	containerWidth: number,
+	containerHeight: number,
+	naturalWidth: number,
+	naturalHeight: number
+): boolean {
+	if (!naturalWidth || !naturalHeight || !containerWidth || !containerHeight) return false;
+	return naturalWidth > containerWidth || naturalHeight > containerHeight;
+}


### PR DESCRIPTION
## Summary
- `fitScale` was computed once at image load and capped at `1` whenever the image already fit within the panel — clicking "Fit to viewport" on a small image (e.g. a RAW file's embedded thumbnail preview) did nothing visible.
- Extracted the scale math into `directImageViewerLogic.ts` (unit tested): `computeFitScale` is now always scale-to-contain, upscaling small images as well as downscaling large ones. `shouldDefaultToFit` decides the default/reset view — auto-shrink only if the image actually overflows the panel, otherwise native size (so small images aren't upscaled unless explicitly requested).
- The toolbar button is now a real toggle (native size ↔ fill viewport) rather than a one-way "shrink if needed" action, and highlights (reusing the existing `.toolbar button.active` style) when in the "fitted" state.
- Added a `ResizeObserver` so the fitted scale stays correct across panel/window resizes.

Found via a real repro case: a Nikon D850 `.NEF` RAW preview in find-anything-demo's `examples/images/` source, whose embedded preview thumbnail is much smaller than a typical viewer panel.

## Test plan
- [x] `pnpm run check` — 0 errors
- [x] `pnpm run test` — 264/264 passing (7 new tests for `computeFitScale`/`shouldDefaultToFit`)
- [x] Manually verified against the reported repro (small `.nef` preview) in a local build