### PR TITLE
fix: include find-preview-dicom in release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
             "find-extract-dispatch"
             "find-extract-dicom"
             "find-extract-pe"
+            "find-preview-dicom"
           )
 
           mkdir -p "dist/${ARTIFACT}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- **`find-preview-dicom` was missing from release tarballs** — same class of bug as [#70](https://github.com/outsharked/find-anything/pull/70) (which added `find-extract-dicom`/`find-extract-pe` but missed this one): the release packaging `BINARIES` list in `.github/workflows/release.yml` never included `find-preview-dicom`, so the DICOM inline image viewer (`GET /api/v1/view` for `.dcm` files) failed with `failed to spawn find-preview-dicom: No such file or directory` in every release build, even though DICOM metadata extraction worked fine.
+
 ---
 
 ## [0.8.1] - 2026-07-10


### PR DESCRIPTION
## Summary
- Same class of bug as #70 (`find-extract-dicom`/`find-extract-pe`), just missed there: the release packaging `BINARIES` list in `.github/workflows/release.yml` never included `find-preview-dicom`.
- Effect: the DICOM inline image viewer (`GET /api/v1/view` for `.dcm` files) fails with `failed to spawn find-preview-dicom: No such file or directory` in every release build — DICOM metadata extraction/indexing works fine, but the actual image preview does not.
- Found via a real repro in find-anything-demo: DICOM metadata displayed correctly in the UI, but the rendered image was broken, against the v0.8.1 release build.

## Test plan
- [x] `cargo build --release --workspace` already produces `find-preview-dicom` (confirmed `crates/preview-dicom` has a `[[bin]]` target and is a workspace member)
- [ ] Next tagged release should have `find-preview-dicom` present in the tarball
- [ ] Re-run find-anything-demo's `dicom/` category against that release to confirm the inline image view actually renders (this is exactly the step #70 left unchecked, which is why this slipped through)